### PR TITLE
Add basic CLI for creating transactions

### DIFF
--- a/bin/dune
+++ b/bin/dune
@@ -11,3 +11,16 @@
  (modules Genesis_helper)
  (preprocess
   (pps ppx_deriving_yojson)))
+
+(executable
+ (name sidecli)
+ (libraries
+  opium
+  node
+  mirage-crypto-ec
+  mirage-crypto-rng.unix
+  helpers
+  cmdliner)
+ (modules Sidecli)
+ (preprocess
+  (pps ppx_deriving_yojson)))

--- a/bin/http_server.re
+++ b/bin/http_server.re
@@ -157,6 +157,14 @@ let handle_data_to_smart_contract =
       });
     },
   );
+let handle_receive_operation_gossip =
+  handle_request(
+    (module Operation_gossip),
+    (update_state, request) => {
+      Flows.received_operation(Server.get_state(), update_state, request);
+      Ok();
+    },
+  );
 module Utils = {
   let read_file = file => {
     let.await ic = Lwt_io.open_file(~mode=Input, file);
@@ -252,6 +260,7 @@ let _server =
   |> handle_request_nonce
   |> handle_register_uri
   |> handle_data_to_smart_contract
+  |> handle_receive_operation_gossip
   |> App.start
   |> Lwt_main.run;
 

--- a/bin/sidecli.re
+++ b/bin/sidecli.re
@@ -1,0 +1,242 @@
+open Helpers;
+open Node;
+open State;
+open Protocol;
+open Cmdliner;
+
+Printexc.record_backtrace(true);
+
+// Helpers
+
+let read_file = file => {
+  let.await ic = Lwt_io.open_file(~mode=Input, file);
+  let.await lines = Lwt_io.read_lines(ic) |> Lwt_stream.to_list;
+  let.await () = Lwt_io.close(ic);
+  await(lines |> String.concat("\n"));
+};
+let read_file = file => read_file(file) |> Lwt_main.run;
+let read_identity_file = file => {
+  let file_buffer = read_file(file);
+  let json = Yojson.Safe.from_string(file_buffer);
+  identity_of_yojson(json) |> Result.get_ok;
+};
+
+// Todo from Andre: we may have to do peer discovery?
+// I don't know anything about that, except for having played with hyperswarm.
+let validators = () => [
+  read_identity_file("0/identity.json"),
+  // read_identity_file("1/identity.json"),
+  read_identity_file("2/identity.json"),
+  // read_identity_file("identity_3.json"),
+];
+
+let make_filename_from_address = wallet_addr_str => {
+  Printf.sprintf("%s.tzsidewallet", wallet_addr_str);
+};
+
+module Serializable = {
+  [@deriving yojson]
+  type wallet_file = {
+    address: Wallet.t,
+    priv_key: Address.key,
+  };
+};
+
+let exits =
+  Term.default_exits
+  @ Term.[exit_info(1, ~doc="expected failure (might not be a bug)")];
+
+// Commands
+// ========
+
+// Create wallet
+
+let info_create_wallet = {
+  let doc = "Creates a wallet file. The wallet file's filename is its address. The wallet file contains the private key corresponding to that address.";
+  let man = [
+    `S(Manpage.s_bugs),
+    `P("Email bug reports to <contact@marigold.dev>."),
+  ];
+  Term.info("create-wallet", ~version="%‌%VERSION%%", ~doc, ~exits, ~man);
+};
+
+let create_wallet = () => {
+  let (key, wallet) = Wallet.make_wallet();
+
+  let swallet: Serializable.wallet_file = {priv_key: key, address: wallet};
+  let to_yojson = Serializable.wallet_file_to_yojson;
+  let wallet_json = swallet |> to_yojson;
+
+  let wallet_addr_str = Wallet.address_to_string(wallet);
+
+  let filename = make_filename_from_address(wallet_addr_str);
+
+  try(`Ok(Yojson.Safe.to_file(filename, wallet_json))) {
+  | _ => `Error((false, "Error writing JSON to file."))
+  };
+};
+
+let create_wallet_t = Term.(ret(const(create_wallet) $ const()));
+
+// Transactions
+
+let info_create_transaction = {
+  let doc =
+    Printf.sprintf(
+      "Submits a transaction to the sidechain. The transaction will be communicated to all known validators to be included in the next block. If the path to the wallet file corresponding to the sending address is not provided, a wallet file with the correct filename (%s) must be present in the current working directory",
+      make_filename_from_address("address"),
+    );
+  let man = [
+    `S(Manpage.s_bugs),
+    `P("Email bug reports to <contact@marigold.dev>."),
+  ];
+  Term.info(
+    "create-transaction",
+    ~version="%‌%VERSION%%",
+    ~doc,
+    ~exits,
+    ~man,
+  );
+};
+
+let create_transaction = (address_sender_str, address_receiver_str, amount) =>
+  switch (
+    address_sender_str == "",
+    address_receiver_str == "",
+    amount <= 0,
+    address_receiver_str
+    |> BLAKE2B.of_string
+    |> Option.map(Wallet.address_of_blake),
+  ) {
+  | (true, _, _, _) =>
+    Lwt.return(
+      `Error((
+        false,
+        "Must provide a sender wallet address, or a path to a wallet file.",
+      )),
+    )
+  | (_, true, _, _) =>
+    Lwt.return(`Error((false, "Must provide a destination wallet address.")))
+  | (_, _, true, _) =>
+    Lwt.return(
+      `Error((false, "Must provide a transaction amount above zero.")),
+    )
+  | (_, _, _, None) =>
+    Lwt.return(
+      `Error((false, "Transaction destination must be a valid address.")),
+    )
+  | (_, _, _, Some(address_to)) =>
+    let transaction = {
+      let input_file =
+        switch (
+          address_sender_str
+          |> BLAKE2B.of_string
+          |> Option.map(Wallet.address_of_blake)
+        ) {
+        | Some(_) => address_sender_str |> make_filename_from_address
+        | None => address_sender_str
+        };
+
+      let.ok wallet_yojson =
+        try(Ok(input_file |> Yojson.Safe.from_file)) {
+        | _ =>
+          Error(
+            Printf.sprintf("failed to read JSON from file %s", input_file),
+          )
+        };
+
+      let.ok wallet = Serializable.wallet_file_of_yojson(wallet_yojson);
+
+      Ok(
+        Operation.self_sign_side(
+          ~key=wallet.priv_key,
+          Operation.Side_chain.make(
+            ~nonce=0l,
+            ~block_height=0L,
+            ~source=wallet.address,
+            ~amount=Amount.of_int(amount),
+            ~kind=Transaction({destination: address_to}),
+          ),
+        ),
+      );
+    };
+    switch (transaction) {
+    | Ok(transaction) =>
+      let validators_uris =
+        List.map(validator => validator.uri, validators());
+
+      // Broadcast transaction
+      let.await () =
+        Networking.broadcast_operation_gossip_to_list(
+          validators_uris,
+          Networking.Operation_gossip.{operation: transaction},
+        );
+
+      Lwt.return(`Ok());
+    | Error(err) => Lwt.return(`Error((false, err)))
+    };
+  };
+
+let create_transaction_t = {
+  let address_from = {
+    let doc = "The sending address, or a path to a wallet. If a bare sending address is provided, the corresponding wallet is assumed to be in the working directory.";
+    let env = Arg.env_var("SENDER", ~doc);
+    let doc = "The message to print.";
+    Arg.(value & pos(0, string, "") & info([], ~env, ~docv="MSG", ~doc));
+  };
+
+  let address_to = {
+    let doc = "The receiving address.";
+    let env = Arg.env_var("RECEIVER", ~doc);
+    let doc = "The message to print.";
+    Arg.(value & pos(1, string, "") & info([], ~env, ~docv="MSG", ~doc));
+  };
+
+  let amount = {
+    let doc = "The amount to be transacted.";
+    let env = Arg.env_var("TRANSFER_AMOUNT", ~doc);
+    let doc = "The message to print.";
+    Arg.(value & pos(2, int, 0) & info([], ~env, ~docv="MSG", ~doc));
+  };
+
+  Term.(
+    ret(
+      const((addr_from, addr_to, amount) =>
+        create_transaction(addr_from, addr_to, amount) |> Lwt_main.run
+      )
+      $ address_from
+      $ address_to
+      $ amount,
+    )
+  );
+};
+
+// Term that just shows the help command, to use when no arguments are passed
+
+let show_help = {
+  let doc = "a tool for interacting with the WIP Tezos Sidechain";
+  let sdocs = Manpage.s_common_options;
+  let exits = Term.default_exits;
+  let man = [
+    `S(Manpage.s_bugs),
+    `P("Email bug reports to <contact@marigold.dev>."),
+  ];
+  (
+    Term.(ret(const(() => `Help((`Pager, None))) $ const())),
+    Term.info("sidecli", ~version="v0.0.1", ~doc, ~sdocs, ~exits, ~man),
+  );
+};
+
+// Run the CLI
+
+let () = {
+  Mirage_crypto_rng_unix.initialize();
+  Term.exit @@
+  Term.eval_choice(
+    show_help,
+    [
+      (create_wallet_t, info_create_wallet),
+      (create_transaction_t, info_create_transaction),
+    ],
+  );
+};

--- a/esy.lock/index.json
+++ b/esy.lock/index.json
@@ -1,5 +1,5 @@
 {
-  "checksum": "9367d9d4dc2d77b0f1953bde29eb74c1",
+  "checksum": "2c5a620ce16b945ec064bbeec8ea83df",
   "root": "sidechain@link-dev:./package.json",
   "node": {
     "yarn-pkg-config@github:esy-ocaml/yarn-pkg-config#db3a0b63883606dd57c54a7158d560d6cba8cd79@d41d8cd9": {
@@ -43,6 +43,7 @@
         "@opam/lwt@opam:5.4.1@37ffbe37", "@opam/hex@opam:1.4.0@41725494",
         "@opam/dune@opam:2.8.5@01003f12",
         "@opam/digestif@opam:1.0.0@ce08dfe9",
+        "@opam/cmdliner@opam:1.0.4@93208aac",
         "@esy-ocaml/reason@3.7.0@d41d8cd9"
       ],
       "devDependencies": [
@@ -1176,7 +1177,7 @@
         "@opam/httpaf-lwt-unix@github:anmonteiro/httpaf:httpaf-lwt-unix.opam#559019829b7ed267a5b4b86aed1e7d7795214bcd@d41d8cd9",
         "@opam/httpaf@github:anmonteiro/httpaf:httpaf.opam#559019829b7ed267a5b4b86aed1e7d7795214bcd@d41d8cd9",
         "@opam/gluten-lwt-unix@opam:0.2.1@1a92c47e",
-        "@opam/faraday@opam:0.7.2@2db86f25",
+        "@opam/faraday@opam:0.7.3@18c4d732",
         "@opam/dune@opam:2.8.5@01003f12",
         "@opam/conf-libssl@opam:3@8025745d",
         "@opam/bigstringaf@opam:0.7.0@152be977",
@@ -1195,7 +1196,7 @@
         "@opam/httpaf-lwt-unix@github:anmonteiro/httpaf:httpaf-lwt-unix.opam#559019829b7ed267a5b4b86aed1e7d7795214bcd@d41d8cd9",
         "@opam/httpaf@github:anmonteiro/httpaf:httpaf.opam#559019829b7ed267a5b4b86aed1e7d7795214bcd@d41d8cd9",
         "@opam/gluten-lwt-unix@opam:0.2.1@1a92c47e",
-        "@opam/faraday@opam:0.7.2@2db86f25",
+        "@opam/faraday@opam:0.7.3@18c4d732",
         "@opam/dune@opam:2.8.5@01003f12",
         "@opam/conf-libssl@opam:3@8025745d",
         "@opam/bigstringaf@opam:0.7.0@152be977",
@@ -2394,7 +2395,7 @@
         "@opam/httpaf-lwt@github:anmonteiro/httpaf:httpaf-lwt.opam#559019829b7ed267a5b4b86aed1e7d7795214bcd@d41d8cd9",
         "@opam/httpaf@github:anmonteiro/httpaf:httpaf.opam#559019829b7ed267a5b4b86aed1e7d7795214bcd@d41d8cd9",
         "@opam/gluten-lwt-unix@opam:0.2.1@1a92c47e",
-        "@opam/faraday-lwt-unix@opam:0.7.2@80e49acc",
+        "@opam/faraday-lwt-unix@opam:0.7.3@e0ae04f9",
         "@opam/dune@opam:2.8.5@01003f12", "@esy-ocaml/substs@0.0.1@d41d8cd9"
       ],
       "devDependencies": [
@@ -2403,7 +2404,7 @@
         "@opam/httpaf-lwt@github:anmonteiro/httpaf:httpaf-lwt.opam#559019829b7ed267a5b4b86aed1e7d7795214bcd@d41d8cd9",
         "@opam/httpaf@github:anmonteiro/httpaf:httpaf.opam#559019829b7ed267a5b4b86aed1e7d7795214bcd@d41d8cd9",
         "@opam/gluten-lwt-unix@opam:0.2.1@1a92c47e",
-        "@opam/faraday-lwt-unix@opam:0.7.2@80e49acc",
+        "@opam/faraday-lwt-unix@opam:0.7.3@e0ae04f9",
         "@opam/dune@opam:2.8.5@01003f12"
       ]
     },
@@ -2451,7 +2452,7 @@
       "dependencies": [
         "ocaml@github:esy-ocaml/ocaml#2e2269f94f3d2b5f9dfa36c1ebcea814f0911ab9@d41d8cd9",
         "@opam/result@opam:1.5@1c6a6533",
-        "@opam/faraday@opam:0.7.2@2db86f25",
+        "@opam/faraday@opam:0.7.3@18c4d732",
         "@opam/dune@opam:2.8.5@01003f12",
         "@opam/bigstringaf@opam:0.7.0@152be977",
         "@opam/angstrom@opam:0.15.0@105656d9",
@@ -2460,7 +2461,7 @@
       "devDependencies": [
         "ocaml@github:esy-ocaml/ocaml#2e2269f94f3d2b5f9dfa36c1ebcea814f0911ab9@d41d8cd9",
         "@opam/result@opam:1.5@1c6a6533",
-        "@opam/faraday@opam:0.7.2@2db86f25",
+        "@opam/faraday@opam:0.7.3@18c4d732",
         "@opam/dune@opam:2.8.5@01003f12",
         "@opam/bigstringaf@opam:0.7.0@152be977",
         "@opam/angstrom@opam:0.15.0@105656d9"
@@ -2547,7 +2548,7 @@
         "@opam/lwt_ssl@opam:1.1.3@653af026", "@opam/lwt@opam:5.4.1@37ffbe37",
         "@opam/gluten-lwt@opam:0.2.1@4dbee72c",
         "@opam/gluten@opam:0.2.1@fca26440",
-        "@opam/faraday-lwt-unix@opam:0.7.2@80e49acc",
+        "@opam/faraday-lwt-unix@opam:0.7.3@e0ae04f9",
         "@opam/dune@opam:2.8.5@01003f12", "@esy-ocaml/substs@0.0.1@d41d8cd9"
       ],
       "devDependencies": [
@@ -2555,7 +2556,7 @@
         "@opam/lwt@opam:5.4.1@37ffbe37",
         "@opam/gluten-lwt@opam:0.2.1@4dbee72c",
         "@opam/gluten@opam:0.2.1@fca26440",
-        "@opam/faraday-lwt-unix@opam:0.7.2@80e49acc",
+        "@opam/faraday-lwt-unix@opam:0.7.3@e0ae04f9",
         "@opam/dune@opam:2.8.5@01003f12"
       ]
     },
@@ -2606,14 +2607,14 @@
       "overrides": [],
       "dependencies": [
         "ocaml@github:esy-ocaml/ocaml#2e2269f94f3d2b5f9dfa36c1ebcea814f0911ab9@d41d8cd9",
-        "@opam/faraday@opam:0.7.2@2db86f25",
+        "@opam/faraday@opam:0.7.3@18c4d732",
         "@opam/dune@opam:2.8.5@01003f12",
         "@opam/bigstringaf@opam:0.7.0@152be977",
         "@esy-ocaml/substs@0.0.1@d41d8cd9"
       ],
       "devDependencies": [
         "ocaml@github:esy-ocaml/ocaml#2e2269f94f3d2b5f9dfa36c1ebcea814f0911ab9@d41d8cd9",
-        "@opam/faraday@opam:0.7.2@2db86f25",
+        "@opam/faraday@opam:0.7.3@18c4d732",
         "@opam/dune@opam:2.8.5@01003f12",
         "@opam/bigstringaf@opam:0.7.0@152be977"
       ]
@@ -2678,27 +2679,27 @@
         "@opam/dune@opam:2.8.5@01003f12"
       ]
     },
-    "@opam/faraday-lwt-unix@opam:0.7.2@80e49acc": {
-      "id": "@opam/faraday-lwt-unix@opam:0.7.2@80e49acc",
+    "@opam/faraday-lwt-unix@opam:0.7.3@e0ae04f9": {
+      "id": "@opam/faraday-lwt-unix@opam:0.7.3@e0ae04f9",
       "name": "@opam/faraday-lwt-unix",
-      "version": "opam:0.7.2",
+      "version": "opam:0.7.3",
       "source": {
         "type": "install",
         "source": [
-          "archive:https://opam.ocaml.org/cache/md5/61/61bb83e1a4bed100eb0bd1365878e3a1#md5:61bb83e1a4bed100eb0bd1365878e3a1",
-          "archive:https://github.com/inhabitedtype/faraday/archive/0.7.2.tar.gz#md5:61bb83e1a4bed100eb0bd1365878e3a1"
+          "archive:https://opam.ocaml.org/cache/md5/1e/1e6d8f5950d099c6ad9ae0e960fe17a9#md5:1e6d8f5950d099c6ad9ae0e960fe17a9",
+          "archive:https://github.com/inhabitedtype/faraday/archive/0.7.3.tar.gz#md5:1e6d8f5950d099c6ad9ae0e960fe17a9"
         ],
         "opam": {
           "name": "faraday-lwt-unix",
-          "version": "0.7.2",
-          "path": "esy.lock/opam/faraday-lwt-unix.0.7.2"
+          "version": "0.7.3",
+          "path": "esy.lock/opam/faraday-lwt-unix.0.7.3"
         }
       },
       "overrides": [],
       "dependencies": [
         "ocaml@github:esy-ocaml/ocaml#2e2269f94f3d2b5f9dfa36c1ebcea814f0911ab9@d41d8cd9",
         "@opam/lwt@opam:5.4.1@37ffbe37",
-        "@opam/faraday-lwt@opam:0.7.2@5105297c",
+        "@opam/faraday-lwt@opam:0.7.3@612dbe66",
         "@opam/dune@opam:2.8.5@01003f12",
         "@opam/base-unix@opam:base@87d0b2eb",
         "@esy-ocaml/substs@0.0.1@d41d8cd9"
@@ -2706,53 +2707,53 @@
       "devDependencies": [
         "ocaml@github:esy-ocaml/ocaml#2e2269f94f3d2b5f9dfa36c1ebcea814f0911ab9@d41d8cd9",
         "@opam/lwt@opam:5.4.1@37ffbe37",
-        "@opam/faraday-lwt@opam:0.7.2@5105297c",
+        "@opam/faraday-lwt@opam:0.7.3@612dbe66",
         "@opam/dune@opam:2.8.5@01003f12",
         "@opam/base-unix@opam:base@87d0b2eb"
       ]
     },
-    "@opam/faraday-lwt@opam:0.7.2@5105297c": {
-      "id": "@opam/faraday-lwt@opam:0.7.2@5105297c",
+    "@opam/faraday-lwt@opam:0.7.3@612dbe66": {
+      "id": "@opam/faraday-lwt@opam:0.7.3@612dbe66",
       "name": "@opam/faraday-lwt",
-      "version": "opam:0.7.2",
+      "version": "opam:0.7.3",
       "source": {
         "type": "install",
         "source": [
-          "archive:https://opam.ocaml.org/cache/md5/61/61bb83e1a4bed100eb0bd1365878e3a1#md5:61bb83e1a4bed100eb0bd1365878e3a1",
-          "archive:https://github.com/inhabitedtype/faraday/archive/0.7.2.tar.gz#md5:61bb83e1a4bed100eb0bd1365878e3a1"
+          "archive:https://opam.ocaml.org/cache/md5/1e/1e6d8f5950d099c6ad9ae0e960fe17a9#md5:1e6d8f5950d099c6ad9ae0e960fe17a9",
+          "archive:https://github.com/inhabitedtype/faraday/archive/0.7.3.tar.gz#md5:1e6d8f5950d099c6ad9ae0e960fe17a9"
         ],
         "opam": {
           "name": "faraday-lwt",
-          "version": "0.7.2",
-          "path": "esy.lock/opam/faraday-lwt.0.7.2"
+          "version": "0.7.3",
+          "path": "esy.lock/opam/faraday-lwt.0.7.3"
         }
       },
       "overrides": [],
       "dependencies": [
         "ocaml@github:esy-ocaml/ocaml#2e2269f94f3d2b5f9dfa36c1ebcea814f0911ab9@d41d8cd9",
-        "@opam/lwt@opam:5.4.1@37ffbe37", "@opam/faraday@opam:0.7.2@2db86f25",
+        "@opam/lwt@opam:5.4.1@37ffbe37", "@opam/faraday@opam:0.7.3@18c4d732",
         "@opam/dune@opam:2.8.5@01003f12", "@esy-ocaml/substs@0.0.1@d41d8cd9"
       ],
       "devDependencies": [
         "ocaml@github:esy-ocaml/ocaml#2e2269f94f3d2b5f9dfa36c1ebcea814f0911ab9@d41d8cd9",
-        "@opam/lwt@opam:5.4.1@37ffbe37", "@opam/faraday@opam:0.7.2@2db86f25",
+        "@opam/lwt@opam:5.4.1@37ffbe37", "@opam/faraday@opam:0.7.3@18c4d732",
         "@opam/dune@opam:2.8.5@01003f12"
       ]
     },
-    "@opam/faraday@opam:0.7.2@2db86f25": {
-      "id": "@opam/faraday@opam:0.7.2@2db86f25",
+    "@opam/faraday@opam:0.7.3@18c4d732": {
+      "id": "@opam/faraday@opam:0.7.3@18c4d732",
       "name": "@opam/faraday",
-      "version": "opam:0.7.2",
+      "version": "opam:0.7.3",
       "source": {
         "type": "install",
         "source": [
-          "archive:https://opam.ocaml.org/cache/md5/61/61bb83e1a4bed100eb0bd1365878e3a1#md5:61bb83e1a4bed100eb0bd1365878e3a1",
-          "archive:https://github.com/inhabitedtype/faraday/archive/0.7.2.tar.gz#md5:61bb83e1a4bed100eb0bd1365878e3a1"
+          "archive:https://opam.ocaml.org/cache/md5/1e/1e6d8f5950d099c6ad9ae0e960fe17a9#md5:1e6d8f5950d099c6ad9ae0e960fe17a9",
+          "archive:https://github.com/inhabitedtype/faraday/archive/0.7.3.tar.gz#md5:1e6d8f5950d099c6ad9ae0e960fe17a9"
         ],
         "opam": {
           "name": "faraday",
-          "version": "0.7.2",
-          "path": "esy.lock/opam/faraday.0.7.2"
+          "version": "0.7.3",
+          "path": "esy.lock/opam/faraday.0.7.3"
         }
       },
       "overrides": [],

--- a/esy.lock/opam/faraday-lwt-unix.0.7.3/opam
+++ b/esy.lock/opam/faraday-lwt-unix.0.7.3/opam
@@ -8,10 +8,10 @@ dev-repo: "git+https://github.com/inhabitedtype/faraday.git"
 build: [
   ["dune" "subst"] {dev}
   ["dune" "build" "-p" name "-j" jobs]
-  ["dune" "runtest" "-p" name] {with-test}
+  ["dune" "runtest" "-p" name "-j" jobs] {with-test}
 ]
 depends: [
-  "ocaml" {>= "4.02.0"}
+  "ocaml" {>= "4.03.0"}
   "dune" {>= "1.11"}
   "faraday-lwt"
   "lwt" {>= "2.7.0"}
@@ -19,6 +19,6 @@ depends: [
 ]
 synopsis: "Lwt_unix support for Faraday"
 url {
-  src: "https://github.com/inhabitedtype/faraday/archive/0.7.2.tar.gz"
-  checksum: "md5=61bb83e1a4bed100eb0bd1365878e3a1"
+  src: "https://github.com/inhabitedtype/faraday/archive/0.7.3.tar.gz"
+  checksum: "md5=1e6d8f5950d099c6ad9ae0e960fe17a9"
 }

--- a/esy.lock/opam/faraday-lwt.0.7.3/opam
+++ b/esy.lock/opam/faraday-lwt.0.7.3/opam
@@ -8,16 +8,16 @@ dev-repo: "git+https://github.com/inhabitedtype/faraday.git"
 build: [
   ["dune" "subst"] {dev}
   ["dune" "build" "-p" name "-j" jobs]
-  ["dune" "runtest" "-p" name] {with-test}
+  ["dune" "runtest" "-p" name "-j" jobs] {with-test}
 ]
 depends: [
-  "ocaml" {>= "4.02.0"}
+  "ocaml" {>= "4.03.0"}
   "dune" {>= "1.11"}
   "faraday" {>= "0.5.0"}
   "lwt"
 ]
 synopsis: "Lwt support for Faraday"
 url {
-  src: "https://github.com/inhabitedtype/faraday/archive/0.7.2.tar.gz"
-  checksum: "md5=61bb83e1a4bed100eb0bd1365878e3a1"
+  src: "https://github.com/inhabitedtype/faraday/archive/0.7.3.tar.gz"
+  checksum: "md5=1e6d8f5950d099c6ad9ae0e960fe17a9"
 }

--- a/esy.lock/opam/faraday.0.7.3/opam
+++ b/esy.lock/opam/faraday.0.7.3/opam
@@ -8,15 +8,15 @@ dev-repo: "git+https://github.com/inhabitedtype/faraday.git"
 build: [
   ["dune" "subst"] {dev}
   ["dune" "build" "-p" name "-j" jobs]
-  ["dune" "runtest" "-p" name] {with-test}
+  ["dune" "runtest" "-p" name "-j" jobs] {with-test}
 ]
 depends: [
-  "ocaml" {>= "4.02.0"}
+  "ocaml" {>= "4.03.0"}
   "dune" {>= "1.11"}
   "alcotest" {with-test & >= "0.4.1"}
   "bigstringaf"
 ]
-synopsis: "A library for writing fast and memory-efficient serializers."
+synopsis: "A library for writing fast and memory-efficient serializers"
 description: """
 Faraday is a library for writing fast and memory-efficient serializers. Its
 core type and related operation gives the user fine-grained control over
@@ -25,6 +25,6 @@ presents the output in a form that makes it possible to use vectorized write
 operations, such as the writev system call, or any other platform or
 application-specific output APIs."""
 url {
-  src: "https://github.com/inhabitedtype/faraday/archive/0.7.2.tar.gz"
-  checksum: "md5=61bb83e1a4bed100eb0bd1365878e3a1"
+  src: "https://github.com/inhabitedtype/faraday/archive/0.7.3.tar.gz"
+  checksum: "md5=1e6d8f5950d099c6ad9ae0e960fe17a9"
 }

--- a/esy.lock/overrides/opam__s__zarith_opam__c__1.12_opam_override/package.json
+++ b/esy.lock/overrides/opam__s__zarith_opam__c__1.12_opam_override/package.json
@@ -1,8 +1,19 @@
 {
-  "exportedEnv": {
-    "CAML_LD_LIBRARY_PATH": {
-      "val": "#{self.lib / 'zarith' : $CAML_LD_LIBRARY_PATH}",
-      "scope": "global"
-    }
-  }
+	"build": [
+		"#{os == 'windows' ? 'env CC=x86_64-w64-mingw32-gcc ': ''}./configure",
+		"make"
+	],
+	"install": [
+		"make install"
+	],
+	"exportedEnv": {
+		"CAML_LD_LIBRARY_PATH": {
+			"val": "#{self.lib / 'zarith' : $CAML_LD_LIBRARY_PATH}",
+			"scope": "global"
+		}
+	},
+	"dependencies": {
+		"ocaml": "*",
+		"@opam/conf-gmp": "*"
+	}
 }

--- a/node/flows.re
+++ b/node/flows.re
@@ -290,6 +290,27 @@ let received_signature = (state, update_state, ~hash, ~signature) => {
   };
 };
 
+open Networking;
+
+let received_operation =
+    (state, update_state, request: Operation_gossip.request) =>
+  if (!List.mem(request.operation, state.Node.pending_side_ops)) {
+    Lwt.async(() => {
+      let _state =
+        update_state(
+          Node.{
+            ...state,
+            pending_side_ops:
+              [request.operation] @ state.Node.pending_side_ops,
+          },
+        );
+      let.await () = broadcast_operation_gossip(state, request);
+      Lwt.return();
+    });
+  } else {
+    ();
+  };
+
 let find_block_by_hash = (state, hash) =>
   Block_pool.find_block(~hash, state.Node.block_pool);
 

--- a/package.json
+++ b/package.json
@@ -22,7 +22,8 @@
     "@opam/mrmime": "0.3.2",
     "@opam/hex": "*",
     "@opam/tezos-micheline": "8.3",
-    "@opam/digestif": "*"
+    "@opam/digestif": "*",
+    "@opam/cmdliner": "1.0.4"
   },
   "devDependencies": {
     "@opam/ocaml-lsp-server": "*",

--- a/protocol/address.re
+++ b/protocol/address.re
@@ -25,6 +25,12 @@ let key_of_yojson =
   | _ => Error("invalid type");
 
 type t = Ed25519.pub_; // TODO: is okay to have this public
+
+let make_pubkey = () => {
+  let (_priv, pub_) = Ed25519.generate();
+  pub_;
+};
+
 let compare = (a, b) =>
   Cstruct.compare(Ed25519.pub_to_cstruct(a), Ed25519.pub_to_cstruct(b));
 let to_yojson = t =>

--- a/protocol/address.rei
+++ b/protocol/address.rei
@@ -10,3 +10,5 @@ let of_key: key => t;
 
 let genesis_key: key;
 let genesis_address: t;
+
+let make_pubkey: unit => t;

--- a/protocol/operation.re
+++ b/protocol/operation.re
@@ -73,3 +73,8 @@ module Side_chain = {
         Wallet.of_address(key) == data.source;
     });
 };
+
+let self_sign_side = (~key, op) => {
+  let Signed.{key, signature, data} = Signed.sign(~key, op);
+  Side_chain.Self_signed.verify(~key, ~signature, data) |> Result.get_ok;
+};

--- a/protocol/operation.rei
+++ b/protocol/operation.rei
@@ -47,3 +47,6 @@ module Side_chain: {
   // TODO: maybe use GADT for this?
   module Self_signed: Signed.S with type data = t;
 };
+
+let self_sign_side:
+  (~key: Address.key, Side_chain.t) => Side_chain.Self_signed.t;

--- a/protocol/wallet.re
+++ b/protocol/wallet.re
@@ -12,3 +12,18 @@ let pubkey_matches_wallet = (key, wallet) => {
   of_address(key) == wallet;
 };
 let get_pub_key = Ed25519.pub_of_priv;
+
+let make_address = () => {
+  let (_key, pub_) = Ed25519.generate();
+  pub_ |> of_address;
+};
+let make_wallet = () => {
+  let (key, pub_) = Ed25519.generate();
+  let wallet_address = of_address(pub_);
+
+  (key, wallet_address);
+};
+let address_to_blake = t => t;
+let address_of_blake = t => t;
+let address_to_string = wallet =>
+  wallet |> address_to_blake |> BLAKE2B.to_string;

--- a/protocol/wallet.rei
+++ b/protocol/wallet.rei
@@ -1,6 +1,14 @@
+open Mirage_crypto_ec;
+open Helpers;
+
 [@deriving (ord, yojson)]
 type t;
 
 let of_address: Address.t => t;
 let pubkey_matches_wallet: (Address.t, t) => bool;
 let get_pub_key: Address.key => Address.t;
+let make_wallet: unit => (Ed25519.priv, t);
+let make_address: unit => t;
+let address_to_blake: t => BLAKE2B.t;
+let address_of_blake: BLAKE2B.t => t;
+let address_to_string: t => string;


### PR DESCRIPTION
This PR has two components:

1) It extends the validators to support gossiping about new operations to include on the chain. It uses a super-simple flood system, where any validator can receive an operation and, if it's new to them, will send it to all the other validator they're connected to (who will then do the same thing etc). Someone could easily DOS the network by sending a bunch of operations really fast, there's no protection against that, and I'm not sure how other blockchains deal with this issue. An easy fix would be to require PoW on each transaction, but that has tradeoffs. 

2) It adds a simple CLI, implemented with Cmdliner, for creating wallets and submitting transactions to the pool of operations.

What still needs to be done, possibly in a future MR:

1) Double check to make sure that validators actually include pending side ops when it's their turn to create blocks.

2) Add tests. The cli currently contains something that should be part of the automated test suite.

3) Move the rest of the command-line tools into this binary, or at least make them use cmdliner so we get nice man pages.