### PR TITLE
Fix tmux script

### DIFF
--- a/.tmuxinator.yml
+++ b/.tmuxinator.yml
@@ -49,9 +49,9 @@ windows:
       # 'before' represents legacy functionality and will be deprecated in a future release, in favour of 'after'
       # synchronize: after
       panes:
-        - sleep 1 && $cur__target_dir/default/bin/http_server.exe identity_0.json
-        - sleep 1 && $cur__target_dir/default/bin/http_server.exe identity_1.json
-        - sleep 1 && $cur__target_dir/default/bin/http_server.exe identity_2.json
-        - sleep 1 && $cur__target_dir/default/bin/http_server.exe identity_3.json
+        - sleep 1 && $cur__target_dir/default/bin/http_server.exe 0
+        - sleep 1 && $cur__target_dir/default/bin/http_server.exe 1
+        - sleep 1 && $cur__target_dir/default/bin/http_server.exe 2
+        - sleep 1 && $cur__target_dir/default/bin/http_server.exe 3
         - $cur__target_dir/default/bin/genesis_helper.exe make-credentials && sleep 3 && $cur__target_dir/default/bin/genesis_helper.exe inject-genesis
 


### PR DESCRIPTION
We changed the structure of the folders that contain the validator info (`identity.json`, `validators.json`, and sometimes `state.bin`), which broke the tmux script we use for testing. This change fixes the tmux script to assume there are 4 folders (named `0`, `1`, `2`, and `3`) each containing a set of validator info.