### PR TITLE
Make hashing and unhashing consistent

### DIFF
--- a/protocol/operation.re
+++ b/protocol/operation.re
@@ -36,7 +36,7 @@ module Side_chain = {
 
   let make = (~nonce, ~block_height, ~source, ~amount, ~kind) => {
     let BLAKE2B.Magic.{hash, _} =
-      BLAKE2B.Magic.hash((nonce, block_height, source, amount, kind));
+      BLAKE2B.Magic.hash((nonce, block_height, source, kind, amount));
     {hash, nonce, block_height, source, kind, amount};
   };
 


### PR DESCRIPTION
Operations could not be deserialized because the way hashes were calculated when serializing and deserializing was not consistent.  This should fix that issue. Ideally, the code would not be duplicated in the first place, I'm interested in comments on how that might be possible.  