### PR TITLE
Make block-height error more informative

### DIFF
--- a/node/building_blocks.re
+++ b/node/building_blocks.re
@@ -9,7 +9,16 @@ let is_valid_block = (state, block) => {
     // TODO: move this out from of_yojson
     true;
   let.assert () = (
-    "new block has a lower block height",
+    String.concat(
+      "",
+      [
+        "new block has a lower block height (",
+        Int64.to_string(block.Block.block_height),
+        ") than the current state (",
+        Int64.to_string(state.Node.protocol.block_height),
+        ").",
+      ],
+    ),
     block.Block.block_height >= state.Node.protocol.block_height,
   );
 

--- a/node/building_blocks.re
+++ b/node/building_blocks.re
@@ -10,10 +10,10 @@ let is_valid_block = (state, block) => {
     true;
   let.assert () = (
     Printf.sprintf(
-      "new block has a lower block height (%Ld) than the current state(%Ld)",
+      "new block has a lower block height (%Ld) than the current state (%Ld)",
       block.Block.block_height,
-      state.Node.protocol.block_height
-    )
+      state.Node.protocol.block_height,
+    ),
     block.Block.block_height >= state.Node.protocol.block_height,
   );
 

--- a/node/building_blocks.re
+++ b/node/building_blocks.re
@@ -9,16 +9,11 @@ let is_valid_block = (state, block) => {
     // TODO: move this out from of_yojson
     true;
   let.assert () = (
-    String.concat(
-      "",
-      [
-        "new block has a lower block height (",
-        Int64.to_string(block.Block.block_height),
-        ") than the current state (",
-        Int64.to_string(state.Node.protocol.block_height),
-        ").",
-      ],
-    ),
+    Printf.sprintf(
+      "new block has a lower block height (%Ld) than the current state(%Ld)",
+      block.Block.block_height,
+      state.Node.protocol.block_height
+    )
     block.Block.block_height >= state.Node.protocol.block_height,
   );
 


### PR DESCRIPTION
The previous block height error just said "new block has a lower block height". This is useful, but it can be handy to know the expected and actual heights (For instance, that can be useful to know it's an off-by-one error or if they're way off). This MR changes the assertion message to include the height of the new block and the expected height, in cases where the block height is not greater than or equal to the expected height. 

This is not a totally free change, since there's probably a tiny cost to the performance caused by creating the string, but I think it should probably be totally undetectable. 