### PR TITLE
Change Address.t to a hash and Wallet.t to a privkey (WIP)

### DIFF
--- a/bin/sidecli.re
+++ b/bin/sidecli.re
@@ -40,7 +40,7 @@ module Serializable = {
   [@deriving yojson]
   type wallet_file = {
     address: Wallet.t,
-    priv_key: Address.key,
+    priv_key: Wallet.t,
   };
 };
 

--- a/node/state.re
+++ b/node/state.re
@@ -3,7 +3,7 @@ open Protocol;
 
 [@deriving yojson]
 type identity = {
-  key: Address.key,
+  key: Wallet.t,
   t: Address.t,
   uri: Uri.t,
 };

--- a/node/state.rei
+++ b/node/state.rei
@@ -3,7 +3,7 @@ open Protocol;
 
 [@deriving yojson]
 type identity = {
-  key: Address.key,
+  key: Wallet.t,
   t: Address.t,
   uri: Uri.t,
 };

--- a/protocol/address.re
+++ b/protocol/address.re
@@ -10,7 +10,7 @@ let of_pubkey = pubkey => {
 };
 let of_wallet = privkey => {
   let pubkey = Wallet.pubkey_of_wallet(privkey);
-  of_pubkey(pubkey)
+  of_pubkey(pubkey);
 };
 
 let address_matches_pubkey = (address, pubkey) => {
@@ -24,17 +24,17 @@ let make_wallet = () => {
   (key, address);
 };
 
-
 let address_to_blake = t => t;
 let address_of_blake = t => t;
 
 let address_to_string = wallet =>
   wallet |> address_to_blake |> BLAKE2B.to_string;
 
-
 let make_address = () => {
-  snd(make_wallet())
+  snd(make_wallet());
 };
 
-
 let genesis_address = of_wallet(Wallet.genesis_key);
+
+let compare = (a, b) =>
+  String.compare(BLAKE2B.to_string(a), BLAKE2B.to_string(b));

--- a/protocol/address.re
+++ b/protocol/address.re
@@ -1,59 +1,40 @@
-open Mirage_crypto_ec;
-
-type key = Ed25519.priv;
+open Helpers;
 
 // TODO: both functions are duplicated
-let to_hex = str => {
-  let `Hex(str) = Hex.of_string(str);
-  str;
+[@deriving yojson]
+type t = BLAKE2B.t;
+
+let of_pubkey = pubkey => {
+  let to_yojson = [%to_yojson: Wallet.pub_];
+  pubkey |> to_yojson |> Yojson.Safe.to_string |> BLAKE2B.hash;
 };
-let of_hex = hex => Hex.to_string(`Hex(hex));
-let key_to_yojson = t =>
-  `String(Ed25519.priv_to_cstruct(t) |> Cstruct.to_string |> to_hex);
-let key_of_yojson =
-  fun
-  | `String(key) =>
-    // TODO: this raises an exception
-    try(
-      of_hex(key)
-      |> Cstruct.of_string
-      |> Ed25519.priv_of_cstruct
-      |> Result.map_error(Format.asprintf("%a", Mirage_crypto_ec.pp_error))
-    ) {
-    | _ => Error("failed to parse")
-    }
-  | _ => Error("invalid type");
-
-type t = Ed25519.pub_; // TODO: is okay to have this public
-
-let make_pubkey = () => {
-  let (_priv, pub_) = Ed25519.generate();
-  pub_;
+let of_wallet = privkey => {
+  let pubkey = Wallet.pubkey_of_wallet(privkey);
+  of_pubkey(pubkey)
 };
 
-let compare = (a, b) =>
-  Cstruct.compare(Ed25519.pub_to_cstruct(a), Ed25519.pub_to_cstruct(b));
-let to_yojson = t =>
-  `String(Ed25519.pub_to_cstruct(t) |> Cstruct.to_string |> to_hex);
-let of_yojson =
-  fun
-  | `String(key) =>
-    try(
-      of_hex(key)
-      |> Cstruct.of_string
-      |> Ed25519.pub_of_cstruct
-      |> Result.map_error(Format.asprintf("%a", Mirage_crypto_ec.pp_error))
-    ) {
-    | _ => Error("failed to parse")
-    }
-  | _ => Error("invalid type");
+let address_matches_pubkey = (address, pubkey) => {
+  of_pubkey(pubkey) == address;
+};
 
-let of_key = Ed25519.pub_of_priv;
+let make_wallet = () => {
+  let (key, pub_) = Wallet.make_pair();
+  let address = of_pubkey(pub_);
 
-let genesis_key = {|fdc6199df66d421df1496785497b3974b36862beac7c543a9c77b99ccf168f02|};
-let genesis_key =
-  switch (key_of_yojson(`String(genesis_key))) {
-  | Ok(key) => key
-  | Error(error) => failwith(error)
-  };
-let genesis_address = Ed25519.pub_of_priv(genesis_key);
+  (key, address);
+};
+
+
+let address_to_blake = t => t;
+let address_of_blake = t => t;
+
+let address_to_string = wallet =>
+  wallet |> address_to_blake |> BLAKE2B.to_string;
+
+
+let make_address = () => {
+  snd(make_wallet())
+};
+
+
+let genesis_address = of_wallet(Wallet.genesis_key);

--- a/protocol/address.rei
+++ b/protocol/address.rei
@@ -4,17 +4,17 @@ open Helpers;
 type t;
 
 let of_wallet: Wallet.t => t;
+let of_pubkey: Wallet.pub_ => t;
 
 let genesis_address: t;
-
 
 let address_to_blake: t => BLAKE2B.t;
 let address_of_blake: BLAKE2B.t => t;
 
-
 let address_to_string: t => string;
-
 
 let address_matches_pubkey: (t, Wallet.pub_) => bool;
 
 let make_address: unit => t;
+
+let compare: (t, t) => int;

--- a/protocol/address.rei
+++ b/protocol/address.rei
@@ -1,14 +1,20 @@
-open Mirage_crypto_ec;
+open Helpers;
 
 [@deriving yojson]
-type key = Ed25519.priv;
+type t;
 
-[@deriving (yojson, ord)]
-type t = Ed25519.pub_;
+let of_wallet: Wallet.t => t;
 
-let of_key: key => t;
-
-let genesis_key: key;
 let genesis_address: t;
 
-let make_pubkey: unit => t;
+
+let address_to_blake: t => BLAKE2B.t;
+let address_of_blake: BLAKE2B.t => t;
+
+
+let address_to_string: t => string;
+
+
+let address_matches_pubkey: (t, Wallet.pub_) => bool;
+
+let make_address: unit => t;

--- a/protocol/block.re
+++ b/protocol/block.re
@@ -179,5 +179,6 @@ open Signature.Make({
        let hash = t => t.hash;
      });
 
-let sign = (~key, t) => sign(~key, t).signature;
+let sign = (~key, t) =>
+  sign(~key=key |> Wallet.wallet_to_privkey, t).signature;
 let verify = (~signature, t) => verify(~signature, t);

--- a/protocol/block.rei
+++ b/protocol/block.rei
@@ -15,7 +15,7 @@ type t =
     side_chain_ops: list(Side_chain.Self_signed.t),
   };
 
-let sign: (~key: Address.key, t) => Signature.t;
+let sign: (~key: Wallet.t, t) => Signature.t;
 let verify: (~signature: Signature.t, t) => bool;
 let genesis: t;
 let produce:

--- a/protocol/ledger.rei
+++ b/protocol/ledger.rei
@@ -1,14 +1,14 @@
 [@deriving yojson]
 type t;
 let empty: t;
-let get_free: (Wallet.t, t) => Amount.t;
-let get_frozen: (Wallet.t, t) => Amount.t;
+let get_free: (Address.t, t) => Amount.t;
+let get_frozen: (Address.t, t) => Amount.t;
 let transfer:
-  (~source: Wallet.t, ~destination: Wallet.t, ~amount: Amount.t, t) => t;
+  (~source: Address.t, ~destination: Address.t, ~amount: Amount.t, t) => t;
 
-let freeze: (~wallet: Wallet.t, ~amount: Amount.t, t) => t;
-let unfreeze: (~wallet: Wallet.t, ~amount: Amount.t, t) => t;
+let freeze: (~wallet: Address.t, ~amount: Amount.t, t) => t;
+let unfreeze: (~wallet: Address.t, ~amount: Amount.t, t) => t;
 
 // on chain ops
-let deposit: (~destination: Wallet.t, ~amount: Amount.t, t) => t;
-let withdraw: (~source: Wallet.t, ~amount: Amount.t, t) => t;
+let deposit: (~destination: Address.t, ~amount: Amount.t, t) => t;
+let withdraw: (~source: Address.t, ~amount: Amount.t, t) => t;

--- a/protocol/operation.re
+++ b/protocol/operation.re
@@ -29,7 +29,7 @@ module Side_chain = {
     hash: BLAKE2B.t,
     nonce: int32,
     block_height: int64,
-    source: Wallet.t,
+    source: Address.t,
     amount: Amount.t,
     kind,
   };
@@ -38,7 +38,7 @@ module Side_chain = {
     /* TODO: this is bad name, it exists like this to prevent
        duplicating all this name parameters */
     let apply = (f, ~nonce, ~block_height, ~source, ~kind, ~amount) => {
-      let to_yojson = [%to_yojson: (int32, int64, Wallet.t, Amount.t, kind)];
+      let to_yojson = [%to_yojson: (int32, int64, Address.t, Amount.t, kind)];
       let json = to_yojson((nonce, block_height, source, amount, kind));
       let payload = Yojson.Safe.to_string(json);
       f(payload);
@@ -70,7 +70,7 @@ module Side_chain = {
       let to_yojson = to_yojson;
       let of_yojson = of_yojson;
       let verify = (~key, ~signature as _, data) =>
-        Wallet.of_address(key) == data.source;
+        Address.of_pubkey(key) == data.source;
     });
 };
 

--- a/protocol/operation.rei
+++ b/protocol/operation.rei
@@ -3,11 +3,11 @@ module Main_chain: {
   [@deriving (ord, yojson)]
   type t =
     | Deposit({
-        destination: Wallet.t,
+        destination: Address.t,
         amount: Amount.t,
       })
     | Withdraw({
-        source: Wallet.t,
+        source: Address.t,
         amount: Amount.t,
       })
     // TODO: can a validator uses the same key in different nodes?
@@ -20,7 +20,7 @@ module Side_chain: {
   // TODO: I don't like this structure model
   [@deriving (ord, yojson)]
   type kind =
-    | Transaction({destination: Wallet.t})
+    | Transaction({destination: Address.t})
     | Freeze
     | Unfreeze;
   [@deriving (ord, yojson)]
@@ -29,7 +29,7 @@ module Side_chain: {
       hash: BLAKE2B.t,
       nonce: int32,
       block_height: int64,
-      source: Wallet.t,
+      source: Address.t,
       amount: Amount.t,
       kind,
     };
@@ -38,7 +38,7 @@ module Side_chain: {
     (
       ~nonce: int32,
       ~block_height: int64,
-      ~source: Wallet.t,
+      ~source: Address.t,
       ~amount: Amount.t,
       ~kind: kind
     ) =>
@@ -48,5 +48,4 @@ module Side_chain: {
   module Self_signed: Signed.S with type data = t;
 };
 
-let self_sign_side:
-  (~key: Address.key, Side_chain.t) => Side_chain.Self_signed.t;
+let self_sign_side: (~key: Wallet.t, Side_chain.t) => Side_chain.Self_signed.t;

--- a/protocol/protocol.re
+++ b/protocol/protocol.re
@@ -54,7 +54,7 @@ let apply_side_chain = (state: t, signed_operation) => {
     raise(Noop("really old operation"));
   };
 
-  if (!Wallet.pubkey_matches_wallet(signed_operation.key, operation.source)) {
+  if (!Address.address_matches_pubkey(operation.source, signed_operation.key)) {
     raise(Noop("invalid key signed the operation"));
   };
 

--- a/protocol/signature.re
+++ b/protocol/signature.re
@@ -5,7 +5,7 @@ open Mirage_crypto_ec;
 type t = {
   // TODO: what is the name of a signature?
   signature: string,
-  public_key: Address.t,
+  public_key: Wallet.pub_,
 };
 // TODO: is it safe to compare only the signature?
 let compare = (a, b) => String.compare(a.signature, b.signature);
@@ -18,7 +18,7 @@ let sign = (~key, hash) => {
     // TODO: isn't this double hashing? Seems weird
     |> Ed25519.sign(~key)
     |> Cstruct.to_string;
-  let public_key = Ed25519.pub_of_priv(key);
+  let public_key = Wallet.(key |> wallet_of_privkey |> pubkey_of_wallet);
   {signature, public_key};
 };
 let signature_to_b58check = t => {
@@ -33,7 +33,7 @@ let signature_to_b58check_by_address = t => {
 let verify = (~signature, hash) => {
   let hash = BLAKE2B.to_raw_string(hash) |> BLAKE2B.hash;
   Ed25519.verify(
-    ~key=signature.public_key,
+    ~key=signature.public_key |> Wallet.pub_to_Ed25519pub,
     ~msg=Cstruct.of_string(BLAKE2B.to_raw_string(hash)),
     Cstruct.of_string(signature.signature),
   );

--- a/protocol/signature.rei
+++ b/protocol/signature.rei
@@ -4,13 +4,13 @@ open Mirage_crypto_ec;
 [@deriving yojson]
 type t;
 let compare: (t, t) => int;
-let public_key: t => Address.t;
+let public_key: t => Wallet.pub_;
 
 let sign: (~key: Ed25519.priv, BLAKE2B.t) => t;
 let verify: (~signature: t, BLAKE2B.t) => bool;
 
 let signature_to_b58check: t => string;
-let signature_to_b58check_by_address: t => (Address.t, string);
+let signature_to_b58check_by_address: t => (Wallet.pub_, string);
 module type S = {
   type value;
   type signature = t;

--- a/protocol/signed.re
+++ b/protocol/signed.re
@@ -41,26 +41,26 @@ module type S = {
   [@deriving (yojson, ord)]
   type t =
     pri {
-      key: Address.t,
+      key: Wallet.pub_,
       signature: string,
       data,
     };
   let verify:
-    (~key: Address.t, ~signature: string, data) => result(t, string);
+    (~key: Wallet.pub_, ~signature: string, data) => result(t, string);
 };
 module Make =
        (
          F: {
            [@deriving (yojson, ord)]
            type t;
-           let verify: (~key: Address.t, ~signature: string, t) => bool;
+           let verify: (~key: Wallet.pub_, ~signature: string, t) => bool;
          },
        ) => {
   [@deriving (yojson, ord)]
   type data = F.t;
   [@deriving (yojson, ord)]
   type t = {
-    key: Address.t,
+    key: Wallet.pub_,
     signature: string,
     data,
   };

--- a/protocol/signed.rei
+++ b/protocol/signed.rei
@@ -1,14 +1,14 @@
 [@deriving (yojson, ord)]
 type t('a) =
   pri {
-    key: Address.t,
+    key: Wallet.pub_,
     signature: string,
     data: 'a,
   };
 [@deriving (yojson, ord)]
 type signed('a) = t('a);
 // TODO: accept a hash function
-let sign: (~key: Address.key, 'a) => t('a);
+let sign: (~key: Wallet.t, 'a) => t('a);
 let verify:
   (~key: Address.t, ~signature: string, 'a) => result(t('a), string);
 
@@ -18,19 +18,19 @@ module type S = {
   [@deriving (yojson, ord)]
   type t =
     pri {
-      key: Address.t,
+      key: Wallet.pub_,
       signature: string,
       data,
     };
   let verify:
-    (~key: Address.t, ~signature: string, data) => result(t, string);
+    (~key: Wallet.pub_, ~signature: string, data) => result(t, string);
 };
 module Make:
   (
     F: {
       [@deriving (yojson, ord)]
       type t;
-      let verify: (~key: Address.t, ~signature: string, t) => bool;
+      let verify: (~key: Wallet.pub_, ~signature: string, t) => bool;
     },
   ) =>
    S with type data = F.t;

--- a/protocol/wallet.re
+++ b/protocol/wallet.re
@@ -3,6 +3,11 @@ open Mirage_crypto_ec;
 type t = Ed25519.priv;
 type pub_ = Ed25519.pub_;
 
+let wallet_of_privkey = priv => priv; 
+let wallet_to_privkey = priv => priv; 
+
+let pub_of_Ed25519pub = pub_ => pub_; 
+let pub_to_Ed25519pub = pub_ => pub_; 
 
 let pubkey_of_wallet = Ed25519.pub_of_priv;
 

--- a/protocol/wallet.re
+++ b/protocol/wallet.re
@@ -1,29 +1,60 @@
-open Helpers;
 open Mirage_crypto_ec;
 
-[@deriving (ord, yojson)]
-type t = BLAKE2B.t;
+type t = Ed25519.priv;
+type pub_ = Ed25519.pub_;
 
-let of_address = pubkey => {
-  let to_yojson = [%to_yojson: Address.t];
-  pubkey |> to_yojson |> Yojson.Safe.to_string |> BLAKE2B.hash;
-};
-let pubkey_matches_wallet = (key, wallet) => {
-  of_address(key) == wallet;
-};
-let get_pub_key = Ed25519.pub_of_priv;
 
-let make_address = () => {
-  let (_key, pub_) = Ed25519.generate();
-  pub_ |> of_address;
-};
-let make_wallet = () => {
-  let (key, pub_) = Ed25519.generate();
-  let wallet_address = of_address(pub_);
+let pubkey_of_wallet = Ed25519.pub_of_priv;
 
-  (key, wallet_address);
+let make_pair = () => Ed25519.generate();
+
+
+let to_hex = str => {
+  let `Hex(str) = Hex.of_string(str);
+  str;
 };
-let address_to_blake = t => t;
-let address_of_blake = t => t;
-let address_to_string = wallet =>
-  wallet |> address_to_blake |> BLAKE2B.to_string;
+let of_hex = hex => Hex.to_string(`Hex(hex));
+
+let to_yojson = t =>
+  `String(Ed25519.priv_to_cstruct(t) |> Cstruct.to_string |> to_hex);
+let of_yojson =
+  fun
+  | `String(key) =>
+    // TODO: this raises an exception
+    try(
+      of_hex(key)
+      |> Cstruct.of_string
+      |> Ed25519.priv_of_cstruct
+      |> Result.map_error(Format.asprintf("%a", Mirage_crypto_ec.pp_error))
+    ) {
+    | _ => Error("failed to parse")
+    }
+  | _ => Error("invalid type");
+let pub_to_yojson = t =>
+  `String(Ed25519.pub_to_cstruct(t) |> Cstruct.to_string |> to_hex);
+let pub_of_yojson =
+  fun
+  | `String(key) =>
+    try(
+      of_hex(key)
+      |> Cstruct.of_string
+      |> Ed25519.pub_of_cstruct
+      |> Result.map_error(Format.asprintf("%a", Mirage_crypto_ec.pp_error))
+    ) {
+    | _ => Error("failed to parse")
+    }
+  | _ => Error("invalid type");
+
+let genesis_key = {|fdc6199df66d421df1496785497b3974b36862beac7c543a9c77b99ccf168f02|};
+let genesis_key =
+  switch (of_yojson(`String(genesis_key))) {
+  | Ok(key) => key
+  | Error(error) => failwith(error)
+  };
+
+
+let compare_pub = (a, b) =>
+  Cstruct.compare(Ed25519.pub_to_cstruct(a), Ed25519.pub_to_cstruct(b));
+
+let compare = (a, b) =>
+  Cstruct.compare(Ed25519.priv_to_cstruct(a), Ed25519.priv_to_cstruct(b));

--- a/protocol/wallet.rei
+++ b/protocol/wallet.rei
@@ -1,14 +1,15 @@
-open Mirage_crypto_ec;
-open Helpers;
-
 [@deriving (ord, yojson)]
 type t;
+[@deriving (ord, yojson)]
+type pub_;
 
-let of_address: Address.t => t;
-let pubkey_matches_wallet: (Address.t, t) => bool;
-let get_pub_key: Address.key => Address.t;
-let make_wallet: unit => (Ed25519.priv, t);
-let make_address: unit => t;
-let address_to_blake: t => BLAKE2B.t;
-let address_of_blake: BLAKE2B.t => t;
-let address_to_string: t => string;
+
+let genesis_key: t;
+
+let pubkey_of_wallet: t => pub_;
+let make_pair: unit => (t, pub_);
+
+let to_hex: string => string;
+let of_hex: string => string;
+
+//let compare_pub: pub_ => pub_ => bool;

--- a/protocol/wallet.rei
+++ b/protocol/wallet.rei
@@ -1,15 +1,19 @@
+open Mirage_crypto_ec;
+
 [@deriving (ord, yojson)]
 type t;
 [@deriving (ord, yojson)]
 type pub_;
 
-
 let genesis_key: t;
+
+let wallet_of_privkey: Ed25519.priv => t;
+let wallet_to_privkey: t => Ed25519.priv;
+let pub_of_Ed25519pub: Ed25519.pub_ => pub_;
+let pub_to_Ed25519pub: pub_ => Ed25519.pub_;
 
 let pubkey_of_wallet: t => pub_;
 let make_pair: unit => (t, pub_);
 
 let to_hex: string => string;
-let of_hex: string => string;
-
-//let compare_pub: pub_ => pub_ => bool;
+let of_hex: string => string /*let compare_pub: pub_ => pub_ => bool*/;


### PR DESCRIPTION
Address.t is conceptually a hash, and Wallet.t is conceptually a private key. Right now, these are reversed. This is my fault and I'm currently in the process of fixing it. (Currently, nothing compiles.) This is a tracking PR to show the status of the transition. 