### PR TITLE
support key_hash on PACK

### DIFF
--- a/tests/test_tezos_interop.re
+++ b/tests/test_tezos_interop.re
@@ -185,6 +185,8 @@ describe("signature", ({test, _}) => {
 describe("pack", ({test, _}) => {
   open Pack;
 
+  // TODO: use ligo to prevent regressions
+
   let test = (name, input, output) =>
     test(
       name,
@@ -218,6 +220,11 @@ describe("pack", ({test, _}) => {
     "key(\"edpkvDqjL7aXdsXSiK5ChCMAfqaqmCFWCv7DaT3dK1egJt136WBiT6\")",
     key(Ed25519(Address.genesis_address)),
     "050a0000002100d00725159de904a28aaed9adb2320f95bd2117959e41c1c2377ac11045d18bd7",
+  );
+  test(
+    "key_hash(\"tz1LzCSmZHG3jDvqxA8SG8WqbrJ9wz5eUCLC\")",
+    key_hash(Key_hash.of_key(Ed25519(Address.genesis_address))),
+    "050a00000015000ec89608700c0414159d93552ef9361cea96da13",
   );
 });
 describe("consensus", ({test, _}) => {

--- a/tezos_interop/tezos_interop.rei
+++ b/tezos_interop/tezos_interop.rei
@@ -46,6 +46,7 @@ module Pack: {
   let pair: (t, t) => t;
   let list: list(t) => t;
   let key: Key.t => t;
+  let key_hash: Key_hash.t => t;
 
   let to_bytes: t => bytes;
 };


### PR DESCRIPTION
## Problem

Most of the problem should be described at #30 but this specifically is being added so we can transmit proofs of withdraw to Tezos for tickets communication.

## Solution

This duplicates Tezos encoding logic to sidechain to avoid having a hard dependency on `tezos-crypto` the logic can be tracked from:

https://gitlab.com/tezos/tezos/-/blob/master/src/lib_crypto/ed25519.ml
https://gitlab.com/tezos/tezos/-/blob/master/src/proto_alpha/lib_protocol/script_ir_translator.ml#L514

## Manual Testing

```shell
echo "let pack = (data: key_hash) => Bytes.pack(data)" > test.religo
ligo evaluate-call test.religo pack "(\"tz1LzCSmZHG3jDvqxA8SG8WqbrJ9wz5eUCLC\": key_hash)"
```

## Related Issues

- #34 