### PR TITLE
support address on tezos_interop

### DIFF
--- a/tests/test_tezos_interop.re
+++ b/tests/test_tezos_interop.re
@@ -1,5 +1,6 @@
 open Setup;
 open Protocol;
+open Address;
 open Tezos_interop;
 
 // TODO: maybe fuzz testing or any other cool testing magic?
@@ -9,7 +10,7 @@ describe("key", ({test, _}) => {
 
   // TODO: test encoding
 
-  let edpk = Ed25519(Address.genesis_address);
+  let edpk = Ed25519(genesis_address);
   test("to_string", ({expect, _}) => {
     expect.string(to_string(edpk)).toEqual(
       "edpkvDqjL7aXdsXSiK5ChCMAfqaqmCFWCv7DaT3dK1egJt136WBiT6",
@@ -54,7 +55,7 @@ describe("key_hash", ({test, _}) => {
   open Key_hash;
 
   // TODO: proper test of_key
-  let tz1 = of_key(Ed25519(Address.genesis_address));
+  let tz1 = of_key(Ed25519(genesis_address));
   test("to_string", ({expect, _}) => {
     expect.string(to_string(tz1)).toEqual(
       "tz1LzCSmZHG3jDvqxA8SG8WqbrJ9wz5eUCLC",
@@ -80,7 +81,7 @@ describe("key_hash", ({test, _}) => {
 describe("secret", ({test, _}) => {
   open Secret;
 
-  let edsk = Ed25519(Address.genesis_key);
+  let edsk = Ed25519(genesis_key);
   test("to_string", ({expect, _}) => {
     expect.string(to_string(edsk)).toEqual(
       "edsk4bfbFdb4s2BdkW3ipfB23i9u82fgji6KT3oj2SCWTeHUthbSVd",
@@ -118,8 +119,8 @@ describe("secret", ({test, _}) => {
 describe("signature", ({test, _}) => {
   open Signature;
 
-  let edpk = Key.Ed25519(Address.genesis_address);
-  let edsk = Secret.Ed25519(Address.genesis_key);
+  let edpk = Key.Ed25519(genesis_address);
+  let edsk = Secret.Ed25519(genesis_key);
 
   // TODO: proper test for sign
   let edsig = sign(edsk, "tuturu");
@@ -182,6 +183,32 @@ describe("signature", ({test, _}) => {
       toBeNone()
   });
 });
+describe("address", ({test, _}) => {
+  open Address;
+
+  let tz1 = Implicit(Key_hash.of_key(Ed25519(genesis_address)));
+  test("to_string", ({expect, _}) => {
+    expect.string(to_string(tz1)).toEqual(
+      "tz1LzCSmZHG3jDvqxA8SG8WqbrJ9wz5eUCLC",
+    )
+  });
+  test("of_string", ({expect, _}) => {
+    expect.option(of_string("tz1LzCSmZHG3jDvqxA8SG8WqbrJ9wz5eUCLC")).toBe(
+      // TODO: proper equals
+      ~equals=(==),
+      Some(tz1),
+    )
+  });
+  test("invalid prefix", ({expect, _}) => {
+    expect.option(of_string("tz4LzCSmZHG3jDvqxA8SG8WqbrJ9wz5eUCLC")).toBeNone()
+  });
+  test("invalid checksum", ({expect, _}) => {
+    expect.option(of_string("tz1LzCSmZHG3jDvqxA8SG8WqbrJ9wz5eUCLd")).toBeNone()
+  });
+  test("invalid size", ({expect, _}) => {
+    expect.option(of_string("tz1LzCSmZHG3jDvqxA8SG8WqbrJ9wz5eUCL")).toBeNone()
+  });
+});
 describe("pack", ({test, _}) => {
   open Pack;
 
@@ -218,13 +245,18 @@ describe("pack", ({test, _}) => {
   );
   test(
     "key(\"edpkvDqjL7aXdsXSiK5ChCMAfqaqmCFWCv7DaT3dK1egJt136WBiT6\")",
-    key(Ed25519(Address.genesis_address)),
+    key(Ed25519(genesis_address)),
     "050a0000002100d00725159de904a28aaed9adb2320f95bd2117959e41c1c2377ac11045d18bd7",
   );
   test(
     "key_hash(\"tz1LzCSmZHG3jDvqxA8SG8WqbrJ9wz5eUCLC\")",
-    key_hash(Key_hash.of_key(Ed25519(Address.genesis_address))),
+    key_hash(Key_hash.of_key(Ed25519(genesis_address))),
     "050a00000015000ec89608700c0414159d93552ef9361cea96da13",
+  );
+  test(
+    "address(\"tz1LzCSmZHG3jDvqxA8SG8WqbrJ9wz5eUCLC\")",
+    address(Implicit(Key_hash.of_key(Ed25519(genesis_address)))),
+    "050a0000001600000ec89608700c0414159d93552ef9361cea96da13",
   );
 });
 describe("consensus", ({test, _}) => {
@@ -273,7 +305,7 @@ describe("consensus", ({test, _}) => {
 describe("discovery", ({test, _}) => {
   open Discovery;
 
-  let secret = Secret.Ed25519(Address.genesis_key);
+  let secret = Secret.Ed25519(genesis_key);
   test("sign", ({expect, _}) => {
     let signature =
       sign(secret, ~nonce=1L, Uri.of_string("http://localhost"));

--- a/tezos_interop/tezos_interop.rei
+++ b/tezos_interop/tezos_interop.rei
@@ -6,7 +6,6 @@ module Key: {
   type t =
     | Ed25519(Mirage_crypto_ec.Ed25519.pub_);
 
-  let encoding: Data_encoding.t(t);
   let to_string: t => string;
   let of_string: string => option(t);
 };
@@ -38,6 +37,14 @@ module Signature: {
   let of_string: string => option(t);
 };
 
+module Address: {
+  type t =
+    | Implicit(Key_hash.t);
+
+  let to_string: t => string;
+  let of_string: string => option(t);
+};
+
 module Pack: {
   type t;
 
@@ -47,6 +54,7 @@ module Pack: {
   let list: list(t) => t;
   let key: Key.t => t;
   let key_hash: Key_hash.t => t;
+  let address: Address.t => t;
 
   let to_bytes: t => bytes;
 };


### PR DESCRIPTION
## Depends

- [x] **#31** 

## Problem

This is required so that we can transmit proofs of withdraw to Tezos for tickets communication.

## Solution

This duplicates Tezos logic to sidechain to avoid having a hard dependency on tezos-crypto the logic can be tracked from:

https://gitlab.com/tezos/tezos/-/blob/master/src/proto_alpha/lib_protocol/contract_repr.ml
https://gitlab.com/tezos/tezos/-/blob/master/src/proto_alpha/lib_protocol/script_ir_translator.ml#L466

## Manual Testing

```shell
echo "let pack = (data: address) => Bytes.pack(data)" > test.religo
ligo evaluate-call test.religo pack "(\"tz1LzCSmZHG3jDvqxA8SG8WqbrJ9wz5eUCLC\": address)"
```

## Related Issues

- #34 