### PR TITLE
support contract_hash on tezos_interop

### DIFF
--- a/tests/test_tezos_interop.re
+++ b/tests/test_tezos_interop.re
@@ -4,7 +4,9 @@ open Address;
 open Tezos_interop;
 
 // TODO: maybe fuzz testing or any other cool testing magic?
-
+let some_contract_hash =
+  Contract_hash.of_string("KT1Dbav7SYrJFpd3bT7sVFDS9MPp4F5gABTc")
+  |> Option.get;
 describe("key", ({test, _}) => {
   open Key;
 
@@ -183,21 +185,55 @@ describe("signature", ({test, _}) => {
       toBeNone()
   });
 });
+describe("contract_hash", ({test, _}) => {
+  open Contract_hash;
+  let kt1 = some_contract_hash;
+  test("to_string", ({expect, _}) => {
+    expect.string(to_string(kt1)).toEqual(
+      "KT1Dbav7SYrJFpd3bT7sVFDS9MPp4F5gABTc",
+    )
+  });
+  test("of_string", ({expect, _}) => {
+    expect.option(of_string("KT1Dbav7SYrJFpd3bT7sVFDS9MPp4F5gABTc")).toBe(
+      // TODO: proper equals
+      ~equals=(==),
+      Some(kt1),
+    )
+  });
+  test("invalid prefix", ({expect, _}) => {
+    expect.option(of_string("KT2Dbav7SYrJFpd3bT7sVFDS9MPp4F5gABTc")).toBeNone()
+  });
+  test("invalid checksum", ({expect, _}) => {
+    expect.option(of_string("KT1Dbav7SYrJFpd3bT7sVFDS9MPp4F5gABTd")).toBeNone()
+  });
+  test("invalid size", ({expect, _}) => {
+    expect.option(of_string("KT1Dbav7SYrJFpd3bT7sVFDS9MPp4F5gABT")).toBeNone()
+  });
+});
 describe("address", ({test, _}) => {
   open Address;
 
   let tz1 = Implicit(Key_hash.of_key(Ed25519(genesis_address)));
+  let kt1 = Originated(some_contract_hash);
   test("to_string", ({expect, _}) => {
     expect.string(to_string(tz1)).toEqual(
       "tz1LzCSmZHG3jDvqxA8SG8WqbrJ9wz5eUCLC",
-    )
+    );
+    expect.string(to_string(kt1)).toEqual(
+      "KT1Dbav7SYrJFpd3bT7sVFDS9MPp4F5gABTc",
+    );
   });
   test("of_string", ({expect, _}) => {
     expect.option(of_string("tz1LzCSmZHG3jDvqxA8SG8WqbrJ9wz5eUCLC")).toBe(
       // TODO: proper equals
       ~equals=(==),
       Some(tz1),
-    )
+    );
+    expect.option(of_string("KT1Dbav7SYrJFpd3bT7sVFDS9MPp4F5gABTc")).toBe(
+      // TODO: proper equals
+      ~equals=(==),
+      Some(kt1),
+    );
   });
   test("invalid prefix", ({expect, _}) => {
     expect.option(of_string("tz4LzCSmZHG3jDvqxA8SG8WqbrJ9wz5eUCLC")).toBeNone()
@@ -257,6 +293,11 @@ describe("pack", ({test, _}) => {
     "address(\"tz1LzCSmZHG3jDvqxA8SG8WqbrJ9wz5eUCLC\")",
     address(Implicit(Key_hash.of_key(Ed25519(genesis_address)))),
     "050a0000001600000ec89608700c0414159d93552ef9361cea96da13",
+  );
+  test(
+    "address(\"KT1Dbav7SYrJFpd3bT7sVFDS9MPp4F5gABTc\")",
+    address(Originated(some_contract_hash)),
+    "050a0000001601370027c6c8f3fbafda4f9bfd08b14f45e6a29ce300",
   );
 });
 describe("consensus", ({test, _}) => {

--- a/tezos_interop/base58.ml
+++ b/tezos_interop/base58.ml
@@ -26,6 +26,7 @@
 
 module Prefix = struct
   (* 20 *)
+  let contract_hash = "\002\090\121" (* KT1(36) *)
   let ed25519_public_key_hash = "\006\161\159" (* tz1(36) *)
 
   (* 32 *)

--- a/tezos_interop/base58.mli
+++ b/tezos_interop/base58.mli
@@ -27,6 +27,8 @@
 (** {1 Prefixed Base58Check encodings} *)
 
 module Prefix : sig
+  val contract_hash : string
+
   val ed25519_public_key_hash : string
 
   val ed25519_public_key : string

--- a/tezos_interop/tezos_interop.rei
+++ b/tezos_interop/tezos_interop.rei
@@ -37,9 +37,17 @@ module Signature: {
   let of_string: string => option(t);
 };
 
+module Contract_hash: {
+  type t = BLAKE2B_20.t;
+
+  let to_string: t => string;
+  let of_string: string => option(t);
+};
+
 module Address: {
   type t =
-    | Implicit(Key_hash.t);
+    | Implicit(Key_hash.t)
+    | Originated(Contract_hash.t);
 
   let to_string: t => string;
   let of_string: string => option(t);


### PR DESCRIPTION
## Depends

- [ ] #32 

## Problem

Currently only smart contracts can hold tickets, so a deposit of tickets from tezos can only happen from an KT1 address, withdraws can also happen to a smartcontract, but sidechains currently doesn't support KT1

## Solution

This duplicates Tezos logic to sidechain to avoid having a hard dependency on tezos-crypto the logic can be tracked from:

https://gitlab.com/tezos/tezos/-/blob/master/src/proto_alpha/lib_protocol/contract_repr.ml

https://gitlab.com/tezos/tezos/-/blob/master/src/proto_alpha/lib_protocol/script_ir_translator.ml#L466

## Manual Testing

```ocaml
echo "let pack = (data: address) => Bytes.pack(data)" > test.religo
ligo evaluate-call test.religo pack "(\"KT1Dbav7SYrJFpd3bT7sVFDS9MPp4F5gABTc\": address)"
```

## Related Issues

- #34 
