### PR TITLE
Toplevel for REPL driven development

### DIFF
--- a/esy.lock/index.json
+++ b/esy.lock/index.json
@@ -1,5 +1,5 @@
 {
-  "checksum": "41a3676ed7f27e8413521ecd8f207b69",
+  "checksum": "7a1c8c30b81f193463d11335669bffac",
   "root": "sidechain@link-dev:./package.json",
   "node": {
     "yocto-queue@0.1.0@d41d8cd9": {
@@ -74,14 +74,14 @@
       "dependencies": [ "isexe@2.0.0@d41d8cd9" ],
       "devDependencies": []
     },
-    "webpack-sources@3.1.2@d41d8cd9": {
-      "id": "webpack-sources@3.1.2@d41d8cd9",
+    "webpack-sources@3.2.0@d41d8cd9": {
+      "id": "webpack-sources@3.2.0@d41d8cd9",
       "name": "webpack-sources",
-      "version": "3.1.2",
+      "version": "3.2.0",
       "source": {
         "type": "install",
         "source": [
-          "archive:https://registry.npmjs.org/webpack-sources/-/webpack-sources-3.1.2.tgz#sha1:614c962ac45dfac7f0f482052db8324a6e0dc274"
+          "archive:https://registry.npmjs.org/webpack-sources/-/webpack-sources-3.2.0.tgz#sha1:b16973bcf844ebcdb3afde32eda1c04d0b90f89d"
         ]
       },
       "overrides": [],
@@ -116,7 +116,7 @@
       },
       "overrides": [],
       "dependencies": [
-        "webpack-merge@5.8.0@d41d8cd9", "webpack@5.47.1@d41d8cd9",
+        "webpack-merge@5.8.0@d41d8cd9", "webpack@5.48.0@d41d8cd9",
         "v8-compile-cache@2.3.0@d41d8cd9", "rechoir@0.7.1@d41d8cd9",
         "interpret@2.2.0@d41d8cd9", "import-local@3.0.2@d41d8cd9",
         "fastest-levenshtein@1.0.12@d41d8cd9", "execa@5.1.1@d41d8cd9",
@@ -128,19 +128,19 @@
       ],
       "devDependencies": []
     },
-    "webpack@5.47.1@d41d8cd9": {
-      "id": "webpack@5.47.1@d41d8cd9",
+    "webpack@5.48.0@d41d8cd9": {
+      "id": "webpack@5.48.0@d41d8cd9",
       "name": "webpack",
-      "version": "5.47.1",
+      "version": "5.48.0",
       "source": {
         "type": "install",
         "source": [
-          "archive:https://registry.npmjs.org/webpack/-/webpack-5.47.1.tgz#sha1:20fb7d76f68912a2249a6dd7ff16faa178049ad2"
+          "archive:https://registry.npmjs.org/webpack/-/webpack-5.48.0.tgz#sha1:06180fef9767a6fd066889559a4c4d49bee19b83"
         ]
       },
       "overrides": [],
       "dependencies": [
-        "webpack-sources@3.1.2@d41d8cd9", "watchpack@2.2.0@d41d8cd9",
+        "webpack-sources@3.2.0@d41d8cd9", "watchpack@2.2.0@d41d8cd9",
         "terser-webpack-plugin@5.1.4@d41d8cd9", "tapable@2.2.0@d41d8cd9",
         "schema-utils@3.1.1@d41d8cd9", "neo-async@2.6.2@d41d8cd9",
         "mime-types@2.1.32@d41d8cd9", "loader-runner@4.2.0@d41d8cd9",
@@ -149,7 +149,8 @@
         "events@3.3.0@d41d8cd9", "eslint-scope@5.1.1@d41d8cd9",
         "es-module-lexer@0.7.1@d41d8cd9", "enhanced-resolve@5.8.2@d41d8cd9",
         "chrome-trace-event@1.0.3@d41d8cd9", "browserslist@4.16.6@d41d8cd9",
-        "acorn@8.4.1@d41d8cd9", "@webassemblyjs/wasm-parser@1.11.1@d41d8cd9",
+        "acorn-import-assertions@1.7.6@d41d8cd9", "acorn@8.4.1@d41d8cd9",
+        "@webassemblyjs/wasm-parser@1.11.1@d41d8cd9",
         "@webassemblyjs/wasm-edit@1.11.1@d41d8cd9",
         "@webassemblyjs/ast@1.11.1@d41d8cd9",
         "@types/estree@0.0.50@d41d8cd9", "@types/eslint-scope@3.7.1@d41d8cd9"
@@ -268,7 +269,7 @@
       },
       "overrides": [],
       "dependencies": [
-        "webpack@5.47.1@d41d8cd9", "terser@5.7.1@d41d8cd9",
+        "webpack@5.48.0@d41d8cd9", "terser@5.7.1@d41d8cd9",
         "source-map@0.6.1@d41d8cd9", "serialize-javascript@6.0.0@d41d8cd9",
         "schema-utils@3.1.1@d41d8cd9", "p-limit@3.1.0@d41d8cd9",
         "jest-worker@27.0.6@d41d8cd9"
@@ -473,7 +474,7 @@
       },
       "overrides": [],
       "dependencies": [
-        "webpack-cli@4.7.2@d41d8cd9", "webpack@5.47.1@d41d8cd9",
+        "webpack-cli@4.7.2@d41d8cd9", "webpack@5.48.0@d41d8cd9",
         "ocaml@github:esy-ocaml/ocaml#7af70dea28d218eb53bce7966e24dfe6762862ae@d41d8cd9",
         "@taquito/taquito@9.2.0@d41d8cd9", "@taquito/signer@9.2.0@d41d8cd9",
         "@opam/tezos-micheline@opam:8.3@f8cfe30f",
@@ -495,8 +496,11 @@
       ],
       "devDependencies": [
         "@reason-native/rely@3.2.1@d41d8cd9",
+        "@opam/utop@opam:2.8.0@76625c33",
         "@opam/ocamlformat@opam:0.19.0@25e59922",
-        "@opam/ocaml-lsp-server@opam:1.7.0@2cdbe0ed"
+        "@opam/ocaml-lsp-server@opam:1.7.0@2cdbe0ed",
+        "@opam/menhir@opam:20210419@11c42419",
+        "@esy-ocaml/rtop@github:ManasJayanth/reason:rtop.json#cb5afe1df701cfc92321f2123fce2dcad39a02aa@d41d8cd9"
       ]
     },
     "shebang-regex@3.0.0@d41d8cd9": {
@@ -2538,6 +2542,20 @@
       ],
       "devDependencies": []
     },
+    "acorn-import-assertions@1.7.6@d41d8cd9": {
+      "id": "acorn-import-assertions@1.7.6@d41d8cd9",
+      "name": "acorn-import-assertions",
+      "version": "1.7.6",
+      "source": {
+        "type": "install",
+        "source": [
+          "archive:https://registry.npmjs.org/acorn-import-assertions/-/acorn-import-assertions-1.7.6.tgz#sha1:580e3ffcae6770eebeec76c3b9723201e9d01f78"
+        ]
+      },
+      "overrides": [],
+      "dependencies": [ "acorn@8.4.1@d41d8cd9" ],
+      "devDependencies": []
+    },
     "acorn@8.4.1@d41d8cd9": {
       "id": "acorn@8.4.1@d41d8cd9",
       "name": "acorn",
@@ -2622,7 +2640,7 @@
       },
       "overrides": [],
       "dependencies": [
-        "webpack-cli@4.7.2@d41d8cd9", "webpack@5.47.1@d41d8cd9"
+        "webpack-cli@4.7.2@d41d8cd9", "webpack@5.48.0@d41d8cd9"
       ],
       "devDependencies": []
     },
@@ -3232,6 +3250,39 @@
       ],
       "devDependencies": []
     },
+    "@opam/zed@opam:3.1.0@86c55416": {
+      "id": "@opam/zed@opam:3.1.0@86c55416",
+      "name": "@opam/zed",
+      "version": "opam:3.1.0",
+      "source": {
+        "type": "install",
+        "source": [
+          "archive:https://opam.ocaml.org/cache/md5/51/51e8676ba972e5ad727633c161e404b1#md5:51e8676ba972e5ad727633c161e404b1",
+          "archive:https://github.com/ocaml-community/zed/archive/3.1.0.tar.gz#md5:51e8676ba972e5ad727633c161e404b1"
+        ],
+        "opam": {
+          "name": "zed",
+          "version": "3.1.0",
+          "path": "esy.lock/opam/zed.3.1.0"
+        }
+      },
+      "overrides": [],
+      "dependencies": [
+        "ocaml@github:esy-ocaml/ocaml#7af70dea28d218eb53bce7966e24dfe6762862ae@d41d8cd9",
+        "@opam/react@opam:1.2.1@0e11855f", "@opam/dune@opam:2.9.0@489e77a9",
+        "@opam/charInfo_width@opam:1.1.0@4296bdfe",
+        "@opam/camomile@opam:1.0.2@4c270e23",
+        "@opam/base-bytes@opam:base@19d0c2ff",
+        "@esy-ocaml/substs@0.0.1@d41d8cd9"
+      ],
+      "devDependencies": [
+        "ocaml@github:esy-ocaml/ocaml#7af70dea28d218eb53bce7966e24dfe6762862ae@d41d8cd9",
+        "@opam/react@opam:1.2.1@0e11855f", "@opam/dune@opam:2.9.0@489e77a9",
+        "@opam/charInfo_width@opam:1.1.0@4296bdfe",
+        "@opam/camomile@opam:1.0.2@4c270e23",
+        "@opam/base-bytes@opam:base@19d0c2ff"
+      ]
+    },
     "@opam/zarith@opam:1.12@232cc7f2": {
       "id": "@opam/zarith@opam:1.12@232cc7f2",
       "name": "@opam/zarith",
@@ -3445,6 +3496,49 @@
         "ocaml@github:esy-ocaml/ocaml#7af70dea28d218eb53bce7966e24dfe6762862ae@d41d8cd9"
       ]
     },
+    "@opam/utop@opam:2.8.0@76625c33": {
+      "id": "@opam/utop@opam:2.8.0@76625c33",
+      "name": "@opam/utop",
+      "version": "opam:2.8.0",
+      "source": {
+        "type": "install",
+        "source": [
+          "archive:https://opam.ocaml.org/cache/sha256/4d/4d2cb88ce598122198726a74274395dd22eacf0a18d9ac24e3047fe962382556#sha256:4d2cb88ce598122198726a74274395dd22eacf0a18d9ac24e3047fe962382556",
+          "archive:https://github.com/ocaml-community/utop/releases/download/2.8.0/utop-2.8.0.tbz#sha256:4d2cb88ce598122198726a74274395dd22eacf0a18d9ac24e3047fe962382556"
+        ],
+        "opam": {
+          "name": "utop",
+          "version": "2.8.0",
+          "path": "esy.lock/opam/utop.2.8.0"
+        }
+      },
+      "overrides": [],
+      "dependencies": [
+        "ocaml@github:esy-ocaml/ocaml#7af70dea28d218eb53bce7966e24dfe6762862ae@d41d8cd9",
+        "@opam/react@opam:1.2.1@0e11855f",
+        "@opam/ocamlfind@opam:1.9.1@b748edf6",
+        "@opam/lwt_react@opam:1.1.4@7d2054d1",
+        "@opam/lwt@opam:5.4.1@37ffbe37",
+        "@opam/lambda-term@opam:3.1.0@ee14e49b",
+        "@opam/dune@opam:2.9.0@489e77a9", "@opam/cppo@opam:1.6.7@57a6d52c",
+        "@opam/camomile@opam:1.0.2@4c270e23",
+        "@opam/base-unix@opam:base@87d0b2eb",
+        "@opam/base-threads@opam:base@36803084",
+        "@esy-ocaml/substs@0.0.1@d41d8cd9"
+      ],
+      "devDependencies": [
+        "ocaml@github:esy-ocaml/ocaml#7af70dea28d218eb53bce7966e24dfe6762862ae@d41d8cd9",
+        "@opam/react@opam:1.2.1@0e11855f",
+        "@opam/ocamlfind@opam:1.9.1@b748edf6",
+        "@opam/lwt_react@opam:1.1.4@7d2054d1",
+        "@opam/lwt@opam:5.4.1@37ffbe37",
+        "@opam/lambda-term@opam:3.1.0@ee14e49b",
+        "@opam/dune@opam:2.9.0@489e77a9",
+        "@opam/camomile@opam:1.0.2@4c270e23",
+        "@opam/base-unix@opam:base@87d0b2eb",
+        "@opam/base-threads@opam:base@36803084"
+      ]
+    },
     "@opam/uri@opam:4.2.0@9c45eeb8": {
       "id": "@opam/uri@opam:4.2.0@9c45eeb8",
       "name": "@opam/uri",
@@ -3558,6 +3652,32 @@
         "ocaml@github:esy-ocaml/ocaml#7af70dea28d218eb53bce7966e24dfe6762862ae@d41d8cd9",
         "@opam/uutf@opam:1.0.2@4440868f", "@opam/seq@opam:base@d8d7de1d",
         "@opam/re@opam:1.9.0@9373f267", "@opam/dune@opam:2.9.0@489e77a9"
+      ]
+    },
+    "@opam/trie@opam:1.0.0@d2efc587": {
+      "id": "@opam/trie@opam:1.0.0@d2efc587",
+      "name": "@opam/trie",
+      "version": "opam:1.0.0",
+      "source": {
+        "type": "install",
+        "source": [
+          "archive:https://opam.ocaml.org/cache/md5/84/84519b5f8bd92490bfc68a52f706ba14#md5:84519b5f8bd92490bfc68a52f706ba14",
+          "archive:https://github.com/kandu/trie/archive/1.0.0.tar.gz#md5:84519b5f8bd92490bfc68a52f706ba14"
+        ],
+        "opam": {
+          "name": "trie",
+          "version": "1.0.0",
+          "path": "esy.lock/opam/trie.1.0.0"
+        }
+      },
+      "overrides": [],
+      "dependencies": [
+        "ocaml@github:esy-ocaml/ocaml#7af70dea28d218eb53bce7966e24dfe6762862ae@d41d8cd9",
+        "@opam/dune@opam:2.9.0@489e77a9", "@esy-ocaml/substs@0.0.1@d41d8cd9"
+      ],
+      "devDependencies": [
+        "ocaml@github:esy-ocaml/ocaml#7af70dea28d218eb53bce7966e24dfe6762862ae@d41d8cd9",
+        "@opam/dune@opam:2.9.0@489e77a9"
       ]
     },
     "@opam/topkg@opam:1.0.3@e4e10f1c": {
@@ -3978,6 +4098,34 @@
       "devDependencies": [
         "ocaml@github:esy-ocaml/ocaml#7af70dea28d218eb53bce7966e24dfe6762862ae@d41d8cd9",
         "@opam/dune@opam:2.9.0@489e77a9"
+      ]
+    },
+    "@opam/react@opam:1.2.1@0e11855f": {
+      "id": "@opam/react@opam:1.2.1@0e11855f",
+      "name": "@opam/react",
+      "version": "opam:1.2.1",
+      "source": {
+        "type": "install",
+        "source": [
+          "archive:https://opam.ocaml.org/cache/md5/ce/ce1454438ce4e9d2931248d3abba1fcc#md5:ce1454438ce4e9d2931248d3abba1fcc",
+          "archive:http://erratique.ch/software/react/releases/react-1.2.1.tbz#md5:ce1454438ce4e9d2931248d3abba1fcc"
+        ],
+        "opam": {
+          "name": "react",
+          "version": "1.2.1",
+          "path": "esy.lock/opam/react.1.2.1"
+        }
+      },
+      "overrides": [],
+      "dependencies": [
+        "ocaml@github:esy-ocaml/ocaml#7af70dea28d218eb53bce7966e24dfe6762862ae@d41d8cd9",
+        "@opam/topkg@opam:1.0.3@e4e10f1c",
+        "@opam/ocamlfind@opam:1.9.1@b748edf6",
+        "@opam/ocamlbuild@opam:0.14.0@6ac75d03",
+        "@esy-ocaml/substs@0.0.1@d41d8cd9"
+      ],
+      "devDependencies": [
+        "ocaml@github:esy-ocaml/ocaml#7af70dea28d218eb53bce7966e24dfe6762862ae@d41d8cd9"
       ]
     },
     "@opam/re@opam:1.9.0@9373f267": {
@@ -5152,6 +5300,62 @@
         "@opam/bigarray-compat@opam:1.0.0@951830c6"
       ]
     },
+    "@opam/mew_vi@opam:0.5.0@cf66c299": {
+      "id": "@opam/mew_vi@opam:0.5.0@cf66c299",
+      "name": "@opam/mew_vi",
+      "version": "opam:0.5.0",
+      "source": {
+        "type": "install",
+        "source": [
+          "archive:https://opam.ocaml.org/cache/md5/34/341e9a9a20383641015bf503952906bc#md5:341e9a9a20383641015bf503952906bc",
+          "archive:https://github.com/kandu/mew_vi/archive/0.5.0.tar.gz#md5:341e9a9a20383641015bf503952906bc"
+        ],
+        "opam": {
+          "name": "mew_vi",
+          "version": "0.5.0",
+          "path": "esy.lock/opam/mew_vi.0.5.0"
+        }
+      },
+      "overrides": [],
+      "dependencies": [
+        "ocaml@github:esy-ocaml/ocaml#7af70dea28d218eb53bce7966e24dfe6762862ae@d41d8cd9",
+        "@opam/react@opam:1.2.1@0e11855f", "@opam/mew@opam:0.1.0@65011d4b",
+        "@opam/dune@opam:2.9.0@489e77a9", "@esy-ocaml/substs@0.0.1@d41d8cd9"
+      ],
+      "devDependencies": [
+        "ocaml@github:esy-ocaml/ocaml#7af70dea28d218eb53bce7966e24dfe6762862ae@d41d8cd9",
+        "@opam/react@opam:1.2.1@0e11855f", "@opam/mew@opam:0.1.0@65011d4b",
+        "@opam/dune@opam:2.9.0@489e77a9"
+      ]
+    },
+    "@opam/mew@opam:0.1.0@65011d4b": {
+      "id": "@opam/mew@opam:0.1.0@65011d4b",
+      "name": "@opam/mew",
+      "version": "opam:0.1.0",
+      "source": {
+        "type": "install",
+        "source": [
+          "archive:https://opam.ocaml.org/cache/md5/22/2298149d1415cd804ab4e01f01ea10a0#md5:2298149d1415cd804ab4e01f01ea10a0",
+          "archive:https://github.com/kandu/mew/archive/0.1.0.tar.gz#md5:2298149d1415cd804ab4e01f01ea10a0"
+        ],
+        "opam": {
+          "name": "mew",
+          "version": "0.1.0",
+          "path": "esy.lock/opam/mew.0.1.0"
+        }
+      },
+      "overrides": [],
+      "dependencies": [
+        "ocaml@github:esy-ocaml/ocaml#7af70dea28d218eb53bce7966e24dfe6762862ae@d41d8cd9",
+        "@opam/trie@opam:1.0.0@d2efc587", "@opam/result@opam:1.5@1c6a6533",
+        "@opam/dune@opam:2.9.0@489e77a9", "@esy-ocaml/substs@0.0.1@d41d8cd9"
+      ],
+      "devDependencies": [
+        "ocaml@github:esy-ocaml/ocaml#7af70dea28d218eb53bce7966e24dfe6762862ae@d41d8cd9",
+        "@opam/trie@opam:1.0.0@d2efc587", "@opam/result@opam:1.5@1c6a6533",
+        "@opam/dune@opam:2.9.0@489e77a9"
+      ]
+    },
     "@opam/merlin-extend@opam:0.6@88755c91": {
       "id": "@opam/merlin-extend@opam:0.6@88755c91",
       "name": "@opam/merlin-extend",
@@ -5344,6 +5548,34 @@
         "@opam/base-unix@opam:base@87d0b2eb"
       ]
     },
+    "@opam/lwt_react@opam:1.1.4@7d2054d1": {
+      "id": "@opam/lwt_react@opam:1.1.4@7d2054d1",
+      "name": "@opam/lwt_react",
+      "version": "opam:1.1.4",
+      "source": {
+        "type": "install",
+        "source": [
+          "archive:https://opam.ocaml.org/cache/md5/fc/fc4721bdb1a01225b96e3a2debde95fa#md5:fc4721bdb1a01225b96e3a2debde95fa",
+          "archive:https://github.com/ocsigen/lwt/archive/5.4.0.zip#md5:fc4721bdb1a01225b96e3a2debde95fa"
+        ],
+        "opam": {
+          "name": "lwt_react",
+          "version": "1.1.4",
+          "path": "esy.lock/opam/lwt_react.1.1.4"
+        }
+      },
+      "overrides": [],
+      "dependencies": [
+        "ocaml@github:esy-ocaml/ocaml#7af70dea28d218eb53bce7966e24dfe6762862ae@d41d8cd9",
+        "@opam/react@opam:1.2.1@0e11855f", "@opam/lwt@opam:5.4.1@37ffbe37",
+        "@opam/dune@opam:2.9.0@489e77a9", "@esy-ocaml/substs@0.0.1@d41d8cd9"
+      ],
+      "devDependencies": [
+        "ocaml@github:esy-ocaml/ocaml#7af70dea28d218eb53bce7966e24dfe6762862ae@d41d8cd9",
+        "@opam/react@opam:1.2.1@0e11855f", "@opam/lwt@opam:5.4.1@37ffbe37",
+        "@opam/dune@opam:2.9.0@489e77a9"
+      ]
+    },
     "@opam/lwt_ppx@opam:2.0.2@d18729de": {
       "id": "@opam/lwt_ppx@opam:2.0.2@d18729de",
       "name": "@opam/lwt_ppx",
@@ -5370,6 +5602,31 @@
         "ocaml@github:esy-ocaml/ocaml#7af70dea28d218eb53bce7966e24dfe6762862ae@d41d8cd9",
         "@opam/ppxlib@opam:0.22.2@61009929", "@opam/lwt@opam:5.4.1@37ffbe37",
         "@opam/dune@opam:2.9.0@489e77a9"
+      ]
+    },
+    "@opam/lwt_log@opam:1.1.1@fc97477f": {
+      "id": "@opam/lwt_log@opam:1.1.1@fc97477f",
+      "name": "@opam/lwt_log",
+      "version": "opam:1.1.1",
+      "source": {
+        "type": "install",
+        "source": [
+          "archive:https://opam.ocaml.org/cache/md5/02/02e93be62288037870ae5b1ce099fe59#md5:02e93be62288037870ae5b1ce099fe59",
+          "archive:https://github.com/aantron/lwt_log/archive/1.1.1.tar.gz#md5:02e93be62288037870ae5b1ce099fe59"
+        ],
+        "opam": {
+          "name": "lwt_log",
+          "version": "1.1.1",
+          "path": "esy.lock/opam/lwt_log.1.1.1"
+        }
+      },
+      "overrides": [],
+      "dependencies": [
+        "@opam/lwt@opam:5.4.1@37ffbe37", "@opam/dune@opam:2.9.0@489e77a9",
+        "@esy-ocaml/substs@0.0.1@d41d8cd9"
+      ],
+      "devDependencies": [
+        "@opam/lwt@opam:5.4.1@37ffbe37", "@opam/dune@opam:2.9.0@489e77a9"
       ]
     },
     "@opam/lwt-canceler@opam:0.2@a2941d49": {
@@ -5467,6 +5724,43 @@
       ],
       "devDependencies": [
         "ocaml@github:esy-ocaml/ocaml#7af70dea28d218eb53bce7966e24dfe6762862ae@d41d8cd9"
+      ]
+    },
+    "@opam/lambda-term@opam:3.1.0@ee14e49b": {
+      "id": "@opam/lambda-term@opam:3.1.0@ee14e49b",
+      "name": "@opam/lambda-term",
+      "version": "opam:3.1.0",
+      "source": {
+        "type": "install",
+        "source": [
+          "archive:https://opam.ocaml.org/cache/md5/78/78180c04ecfc8060b23d7d0014f24196#md5:78180c04ecfc8060b23d7d0014f24196",
+          "archive:https://github.com/ocaml-community/lambda-term/archive/3.1.0.tar.gz#md5:78180c04ecfc8060b23d7d0014f24196"
+        ],
+        "opam": {
+          "name": "lambda-term",
+          "version": "3.1.0",
+          "path": "esy.lock/opam/lambda-term.3.1.0"
+        }
+      },
+      "overrides": [],
+      "dependencies": [
+        "ocaml@github:esy-ocaml/ocaml#7af70dea28d218eb53bce7966e24dfe6762862ae@d41d8cd9",
+        "@opam/zed@opam:3.1.0@86c55416", "@opam/react@opam:1.2.1@0e11855f",
+        "@opam/mew_vi@opam:0.5.0@cf66c299",
+        "@opam/lwt_react@opam:1.1.4@7d2054d1",
+        "@opam/lwt_log@opam:1.1.1@fc97477f", "@opam/lwt@opam:5.4.1@37ffbe37",
+        "@opam/dune@opam:2.9.0@489e77a9",
+        "@opam/camomile@opam:1.0.2@4c270e23",
+        "@esy-ocaml/substs@0.0.1@d41d8cd9"
+      ],
+      "devDependencies": [
+        "ocaml@github:esy-ocaml/ocaml#7af70dea28d218eb53bce7966e24dfe6762862ae@d41d8cd9",
+        "@opam/zed@opam:3.1.0@86c55416", "@opam/react@opam:1.2.1@0e11855f",
+        "@opam/mew_vi@opam:0.5.0@cf66c299",
+        "@opam/lwt_react@opam:1.1.4@7d2054d1",
+        "@opam/lwt_log@opam:1.1.1@fc97477f", "@opam/lwt@opam:5.4.1@37ffbe37",
+        "@opam/dune@opam:2.9.0@489e77a9",
+        "@opam/camomile@opam:1.0.2@4c270e23"
       ]
     },
     "@opam/ke@opam:0.4@10bac7d7": {
@@ -6671,6 +6965,61 @@
         "ocaml@github:esy-ocaml/ocaml#7af70dea28d218eb53bce7966e24dfe6762862ae@d41d8cd9"
       ]
     },
+    "@opam/charInfo_width@opam:1.1.0@4296bdfe": {
+      "id": "@opam/charInfo_width@opam:1.1.0@4296bdfe",
+      "name": "@opam/charInfo_width",
+      "version": "opam:1.1.0",
+      "source": {
+        "type": "install",
+        "source": [
+          "archive:https://opam.ocaml.org/cache/md5/a5/a539436d1da4aeb93711303f107bec7e#md5:a539436d1da4aeb93711303f107bec7e",
+          "archive:https://github.com/kandu/charInfo_width/archive/1.1.0.tar.gz#md5:a539436d1da4aeb93711303f107bec7e"
+        ],
+        "opam": {
+          "name": "charInfo_width",
+          "version": "1.1.0",
+          "path": "esy.lock/opam/charInfo_width.1.1.0"
+        }
+      },
+      "overrides": [],
+      "dependencies": [
+        "ocaml@github:esy-ocaml/ocaml#7af70dea28d218eb53bce7966e24dfe6762862ae@d41d8cd9",
+        "@opam/result@opam:1.5@1c6a6533", "@opam/dune@opam:2.9.0@489e77a9",
+        "@opam/camomile@opam:1.0.2@4c270e23",
+        "@esy-ocaml/substs@0.0.1@d41d8cd9"
+      ],
+      "devDependencies": [
+        "ocaml@github:esy-ocaml/ocaml#7af70dea28d218eb53bce7966e24dfe6762862ae@d41d8cd9",
+        "@opam/result@opam:1.5@1c6a6533", "@opam/dune@opam:2.9.0@489e77a9",
+        "@opam/camomile@opam:1.0.2@4c270e23"
+      ]
+    },
+    "@opam/camomile@opam:1.0.2@4c270e23": {
+      "id": "@opam/camomile@opam:1.0.2@4c270e23",
+      "name": "@opam/camomile",
+      "version": "opam:1.0.2",
+      "source": {
+        "type": "install",
+        "source": [
+          "archive:https://opam.ocaml.org/cache/sha256/f0/f0a419b0affc36500f83b086ffaa36c545560cee5d57e84b729e8f851b3d1632#sha256:f0a419b0affc36500f83b086ffaa36c545560cee5d57e84b729e8f851b3d1632",
+          "archive:https://github.com/yoriyuki/Camomile/releases/download/1.0.2/camomile-1.0.2.tbz#sha256:f0a419b0affc36500f83b086ffaa36c545560cee5d57e84b729e8f851b3d1632"
+        ],
+        "opam": {
+          "name": "camomile",
+          "version": "1.0.2",
+          "path": "esy.lock/opam/camomile.1.0.2"
+        }
+      },
+      "overrides": [],
+      "dependencies": [
+        "ocaml@github:esy-ocaml/ocaml#7af70dea28d218eb53bce7966e24dfe6762862ae@d41d8cd9",
+        "@opam/dune@opam:2.9.0@489e77a9", "@esy-ocaml/substs@0.0.1@d41d8cd9"
+      ],
+      "devDependencies": [
+        "ocaml@github:esy-ocaml/ocaml#7af70dea28d218eb53bce7966e24dfe6762862ae@d41d8cd9",
+        "@opam/dune@opam:2.9.0@489e77a9"
+      ]
+    },
     "@opam/biniou@opam:1.2.1@420bda02": {
       "id": "@opam/biniou@opam:1.2.1@420bda02",
       "name": "@opam/biniou",
@@ -6989,6 +7338,30 @@
       "overrides": [],
       "dependencies": [],
       "devDependencies": []
+    },
+    "@esy-ocaml/rtop@github:ManasJayanth/reason:rtop.json#cb5afe1df701cfc92321f2123fce2dcad39a02aa@d41d8cd9": {
+      "id":
+        "@esy-ocaml/rtop@github:ManasJayanth/reason:rtop.json#cb5afe1df701cfc92321f2123fce2dcad39a02aa@d41d8cd9",
+      "name": "@esy-ocaml/rtop",
+      "version":
+        "github:ManasJayanth/reason:rtop.json#cb5afe1df701cfc92321f2123fce2dcad39a02aa",
+      "source": {
+        "type": "install",
+        "source": [
+          "github:ManasJayanth/reason:rtop.json#cb5afe1df701cfc92321f2123fce2dcad39a02aa"
+        ]
+      },
+      "overrides": [],
+      "dependencies": [
+        "ocaml@github:esy-ocaml/ocaml#7af70dea28d218eb53bce7966e24dfe6762862ae@d41d8cd9",
+        "@opam/utop@opam:2.8.0@76625c33", "@opam/result@opam:1.5@1c6a6533",
+        "@opam/ocamlfind@opam:1.9.1@b748edf6",
+        "@opam/dune@opam:2.9.0@489e77a9", "@esy-ocaml/substs@0.0.1@d41d8cd9",
+        "@esy-ocaml/reason@3.7.0@d41d8cd9"
+      ],
+      "devDependencies": [
+        "ocaml@github:esy-ocaml/ocaml#7af70dea28d218eb53bce7966e24dfe6762862ae@d41d8cd9"
+      ]
     },
     "@esy-ocaml/reason@3.7.0@d41d8cd9": {
       "id": "@esy-ocaml/reason@3.7.0@d41d8cd9",

--- a/esy.lock/opam/camomile.1.0.2/opam
+++ b/esy.lock/opam/camomile.1.0.2/opam
@@ -1,0 +1,35 @@
+opam-version: "2.0"
+synopsis: "A Unicode library"
+description: """
+Camomile is a Unicode library for OCaml. Camomile provides Unicode character
+type, UTF-8, UTF-16, UTF-32 strings, conversion to/from about 200 encodings,
+collation and locale-sensitive case mappings, and more. The library is currently
+designed for Unicode Standard 3.2."""
+maintainer: ["yoriyuki.y@gmail.com"]
+authors: ["Yoriyuki Yamagata"]
+license: "LGPL-2.1-or-later with OCaml-LGPL-linking-exception"
+homepage: "https://github.com/yoriyuki/Camomile"
+doc: "https://yoriyuki.github.io/Camomile/"
+bug-reports: "https://github.com/yoriyuki/Camomile/issues"
+depends: [
+  "dune" {>= "1.11"}
+  "ocaml" {>= "4.02.3"}
+]
+dev-repo: "git+https://github.com/yoriyuki/Camomile.git"
+build: [
+  ["ocaml" "configure.ml" "--share" "%{share}%/camomile"]
+  ["dune" "subst"] {dev}
+  ["dune" "build" "-p" name "-j" jobs
+    "@install"
+    "@doc" {with-doc}
+  ]
+]
+url {
+  src:
+    "https://github.com/yoriyuki/Camomile/releases/download/1.0.2/camomile-1.0.2.tbz"
+  checksum: [
+    "sha256=f0a419b0affc36500f83b086ffaa36c545560cee5d57e84b729e8f851b3d1632"
+    "sha512=7586422e68779476206027c6ebbe19b677fbe459153221f7c952c7fae374c5c8232249cb76fdb1f482069707aa1580be827cd39693906142988268b7f0e7f6d0"
+  ]
+}
+available: arch != "ppc64"

--- a/esy.lock/opam/charInfo_width.1.1.0/opam
+++ b/esy.lock/opam/charInfo_width.1.1.0/opam
@@ -1,0 +1,27 @@
+opam-version: "2.0"
+maintainer: "zandoye@gmail.com"
+authors: [ "ZAN DoYe" ]
+homepage: "https://github.com/kandu/charinfo_width/"
+bug-reports: "https://github.com/kandu/charinfo_width/issues"
+license: "MIT"
+dev-repo: "git://github.com/kandu/charinfo_width.git"
+build: [
+  ["dune" "build" "-p" name "-j" jobs]
+  ["dune" "runtest" "-p" name "-j" jobs] {with-test & (ocaml:version >= "4.04.0")}
+]
+depends: [
+  "ocaml" {>= "4.02.3"}
+  "result"
+  "camomile" {>= "1.0.0" & < "2.0~"}
+  "dune"
+  "ppx_expect" {with-test & < "v0.15"}
+]
+
+synopsis: "Determine column width for a character"
+description: """
+This module is implemented purely in OCaml and the width function follows the prototype of POSIX's wcwidth."""
+
+url {
+  src:"https://github.com/kandu/charInfo_width/archive/1.1.0.tar.gz"
+  checksum: "md5=a539436d1da4aeb93711303f107bec7e"
+}

--- a/esy.lock/opam/lambda-term.3.1.0/opam
+++ b/esy.lock/opam/lambda-term.3.1.0/opam
@@ -1,0 +1,35 @@
+opam-version: "2.0"
+maintainer: "jeremie@dimino.org"
+authors: ["Jérémie Dimino"]
+homepage: "https://github.com/ocaml-community/lambda-term"
+bug-reports: "https://github.com/ocaml-community/lambda-term/issues"
+dev-repo: "git://github.com/ocaml-community/lambda-term.git"
+license: "BSD-3-Clause"
+build: [
+  ["dune" "build" "-p" name "-j" jobs]
+  ["dune" "runtest" "-p" name "-j" jobs] {with-test}
+]
+depends: [
+  "ocaml" {>= "4.02.3"}
+  "lwt"   {>= "4.2.0"}
+  "lwt_log"
+  "react"
+  "zed"   {>= "3.1.0" & < "4.0"}
+  "camomile" {>= "1.0.1"}
+  "lwt_react"
+  "mew_vi"  {>= "0.5.0" & < "0.6.0"}
+  "dune" {>= "1.1.0"}
+]
+synopsis: "Terminal manipulation library for OCaml"
+description: """
+Lambda-term is a cross-platform library for manipulating the terminal. It
+provides an abstraction for keys, mouse events, colors, as well as a set of
+widgets to write curses-like applications. The main objective of lambda-term is
+to provide a higher level functional interface to terminal manipulation than,
+for example, ncurses, by providing a native OCaml interface instead of bindings
+to a C library. Lambda-term integrates with zed to provide text edition
+facilities in console applications."""
+url {
+  src: "https://github.com/ocaml-community/lambda-term/archive/3.1.0.tar.gz"
+  checksum: "md5=78180c04ecfc8060b23d7d0014f24196"
+}

--- a/esy.lock/opam/lwt_log.1.1.1/opam
+++ b/esy.lock/opam/lwt_log.1.1.1/opam
@@ -1,0 +1,29 @@
+opam-version: "2.0"
+
+synopsis: "Lwt logging library (deprecated)"
+
+license: "LGPL-2.0-or-later"
+homepage: "https://github.com/ocsigen/lwt_log"
+doc: "https://github.com/ocsigen/lwt_log/blob/master/src/core/lwt_log_core.mli"
+bug-reports: "https://github.com/ocsigen/lwt_log/issues"
+
+authors: [
+  "Shawn Wagner"
+  "Jérémie Dimino"
+]
+maintainer: "Anton Bachin <antonbachin@yahoo.com>"
+dev-repo: "git+https://github.com/ocsigen/lwt_log.git"
+
+depends: [
+  "dune" {>= "1.0"}
+  "lwt" {>= "4.0.0"}
+]
+
+build: [
+  ["dune" "build" "-p" name "-j" jobs]
+]
+
+url {
+  src: "https://github.com/aantron/lwt_log/archive/1.1.1.tar.gz"
+  checksum: "md5=02e93be62288037870ae5b1ce099fe59"
+}

--- a/esy.lock/opam/lwt_react.1.1.4/opam
+++ b/esy.lock/opam/lwt_react.1.1.4/opam
@@ -1,0 +1,23 @@
+opam-version: "2.0"
+synopsis: "Helpers for using React with Lwt"
+maintainer: "Anton Bachin <antonbachin@yahoo.com>"
+authors: "Jérémie Dimino"
+license: "MIT"
+homepage: "https://github.com/ocsigen/lwt"
+doc: "https://ocsigen.org/lwt/dev/api/Lwt_react"
+bug-reports: "https://github.com/ocsigen/lwt/issues"
+depends: [
+  "dune" {>= "1.8.0"}
+  "lwt" {>= "3.0.0"}
+  "ocaml"
+  "react" {>= "1.0.0"}
+]
+build: ["dune" "build" "-p" name "-j" jobs]
+dev-repo: "git+https://github.com/ocsigen/lwt.git"
+url {
+  src: "https://github.com/ocsigen/lwt/archive/5.4.0.zip"
+  checksum: [
+    "md5=fc4721bdb1a01225b96e3a2debde95fa"
+    "sha512=e427f08223b77f9af696c9e6f90ff68e27e02e446910ef90d3da542e7b00bf23dd191ac77c1871288faa2289f8d28fc2f44efc3d3fe9165fe1c7a6be88ee49ff"
+  ]
+}

--- a/esy.lock/opam/mew.0.1.0/opam
+++ b/esy.lock/opam/mew.0.1.0/opam
@@ -1,0 +1,25 @@
+opam-version: "2.0"
+maintainer: "zandoye@gmail.com"
+authors: [ "ZAN DoYe" ]
+homepage: "https://github.com/kandu/mew"
+bug-reports: "https://github.com/kandu/mew/issues"
+license: "MIT"
+dev-repo: "git+https://github.com/kandu/mew.git"
+build: [
+  ["dune" "build" "-p" name "-j" jobs]
+]
+depends: [
+  "ocaml" {>= "4.02.3"}
+  "result"
+  "trie" {>= "1.0.0"}
+  "dune" {>= "1.1.0"}
+]
+
+synopsis: "Modal editing witch"
+description: """
+This is the core module of mew, a general modal editing engine generator."""
+
+url {
+  src: "https://github.com/kandu/mew/archive/0.1.0.tar.gz"
+  checksum: "md5=2298149d1415cd804ab4e01f01ea10a0"
+}

--- a/esy.lock/opam/mew_vi.0.5.0/opam
+++ b/esy.lock/opam/mew_vi.0.5.0/opam
@@ -1,0 +1,25 @@
+opam-version: "2.0"
+maintainer: "zandoye@gmail.com"
+authors: [ "ZAN DoYe" ]
+homepage: "https://github.com/kandu/mew_vi"
+bug-reports: "https://github.com/kandu/mew_vi/issues"
+license: "MIT"
+dev-repo: "git+https://github.com/kandu/mew_vi.git"
+build: [
+  ["dune" "build" "-p" name "-j" jobs]
+]
+depends: [
+  "ocaml" {>= "4.02.3"}
+  "mew" {>= "0.1.0" & < "0.2"}
+  "react"
+  "dune" {>= "1.1.0"}
+]
+
+synopsis: "Modal editing witch, VI interpreter"
+description: """
+A vi-like modal editing engine generator."""
+
+url {
+  src: "https://github.com/kandu/mew_vi/archive/0.5.0.tar.gz"
+  checksum: "md5=341e9a9a20383641015bf503952906bc"
+}

--- a/esy.lock/opam/react.1.2.1/opam
+++ b/esy.lock/opam/react.1.2.1/opam
@@ -1,0 +1,33 @@
+opam-version: "2.0"
+maintainer: "Daniel Bünzli <daniel.buenzl i@erratique.ch>"
+homepage: "http://erratique.ch/software/react"
+authors: ["Daniel Bünzli <daniel.buenzl i@erratique.ch>"]
+doc: "http://erratique.ch/software/react/doc/React"
+dev-repo: "git+http://erratique.ch/repos/react.git"
+bug-reports: "https://github.com/dbuenzli/react/issues"
+tags: [ "reactive" "declarative" "signal" "event" "frp" "org:erratique" ]
+license: "ISC"
+depends: [
+  "ocaml" {>= "4.01.0"}
+  "ocamlfind" {build}
+  "ocamlbuild" {build}
+  "topkg" {build & >= "0.9.0"}
+]
+build:
+[[ "ocaml" "pkg/pkg.ml" "build"
+           "--dev-pkg" "%{pinned}%" ]]
+synopsis: "Declarative events and signals for OCaml"
+description: """
+Release %%VERSION%%
+
+React is an OCaml module for functional reactive programming (FRP). It
+provides support to program with time varying values : declarative
+events and signals. React doesn't define any primitive event or
+signal, it lets the client chooses the concrete timeline.
+
+React is made of a single, independent, module and distributed under
+the ISC license."""
+url {
+  src: "http://erratique.ch/software/react/releases/react-1.2.1.tbz"
+  checksum: "md5=ce1454438ce4e9d2931248d3abba1fcc"
+}

--- a/esy.lock/opam/trie.1.0.0/opam
+++ b/esy.lock/opam/trie.1.0.0/opam
@@ -1,0 +1,19 @@
+opam-version: "2.0"
+maintainer: "zandoye@gmail.com"
+authors: [ "ZAN DoYe" ]
+homepage: "https://github.com/kandu/trie/"
+bug-reports: "https://github.com/kandu/trie/issues"
+license: "MIT"
+dev-repo: "git://github.com/kandu/trie.git"
+build: [
+  ["dune" "build" "-p" name "-j" jobs]
+]
+depends: [
+  "ocaml" {>= "4.02"}
+  "dune" {>= "1.0"}
+]
+synopsis: "Strict impure trie tree"
+url {
+  src: "https://github.com/kandu/trie/archive/1.0.0.tar.gz"
+  checksum: "md5=84519b5f8bd92490bfc68a52f706ba14"
+}

--- a/esy.lock/opam/utop.2.8.0/opam
+++ b/esy.lock/opam/utop.2.8.0/opam
@@ -1,0 +1,42 @@
+opam-version: "2.0"
+maintainer: "jeremie@dimino.org"
+authors: "Jérémie Dimino"
+license: "BSD-3-Clause"
+homepage: "https://github.com/ocaml-community/utop"
+bug-reports: "https://github.com/ocaml-community/utop/issues"
+doc: "https://ocaml-community.github.io/utop/"
+depends: [
+  "ocaml" {>= "4.03.0"}
+  "base-unix"
+  "base-threads"
+  "ocamlfind" {>= "1.7.2"}
+  "lambda-term" {>= "3.1.0" & < "4.0"}
+  "lwt"
+  "lwt_react"
+  "camomile"
+  "react" {>= "1.0.0"}
+  "cppo" {build & >= "1.1.2"}
+  "dune" {>= "1.0"}
+]
+build: [
+  ["dune" "subst"] {dev}
+  ["dune" "build" "-p" name "-j" jobs]
+  ["dune" "runtest" "-p" name "-j" jobs] {with-test}
+]
+dev-repo: "git+https://github.com/ocaml-community/utop.git"
+synopsis: "Universal toplevel for OCaml"
+description: """
+utop is an improved toplevel (i.e., Read-Eval-Print Loop or REPL) for
+OCaml.  It can run in a terminal or in Emacs. It supports line
+edition, history, real-time and context sensitive completion, colors,
+and more.  It integrates with the Tuareg mode in Emacs.
+"""
+x-commit-hash: "c87b8b2817eefd0cd53564618911386b89b587c5"
+url {
+  src:
+    "https://github.com/ocaml-community/utop/releases/download/2.8.0/utop-2.8.0.tbz"
+  checksum: [
+    "sha256=4d2cb88ce598122198726a74274395dd22eacf0a18d9ac24e3047fe962382556"
+    "sha512=22cdc75e14950eac28d6e0b7b2c6d686aea4e24d9955f140bfcbdef2de033e59f94ab3da0c5c95e1ce51211759694b55c82eec16776c3e0cfb80aa77e64a380b"
+  ]
+}

--- a/esy.lock/opam/zed.3.1.0/opam
+++ b/esy.lock/opam/zed.3.1.0/opam
@@ -1,0 +1,32 @@
+opam-version: "2.0"
+maintainer: "opam-devel@lists.ocaml.org"
+authors: ["Jérémie Dimino"]
+homepage: "https://github.com/ocaml-community/zed"
+bug-reports: "https://github.com/ocaml-community/zed/issues"
+dev-repo: "git://github.com/ocaml-community/zed.git"
+license: "BSD-3-Clause"
+depends: [
+  "ocaml" {>= "4.02.3"}
+  "dune" {>= "1.1.0"}
+  "base-bytes"
+  "camomile" {>= "1.0.1"}
+  "react"
+  "charInfo_width" {>= "1.1.0" & < "2.0~"}
+]
+build: [
+  ["dune" "build" "-p" name "-j" jobs]
+  ["dune" "runtest" "-p" name "-j" jobs] {with-test}
+]
+synopsis: "Abstract engine for text edition in OCaml"
+description: """
+Zed is an abstract engine for text edition. It can be used to write text
+editors, edition widgets, readlines, ... Zed uses Camomile to fully support the
+Unicode specification, and implements an UTF-8 encoded string type with
+validation, and a rope datastructure to achieve efficient operations on large
+Unicode buffers. Zed also features a regular expression search on ropes. To
+support efficient text edition capabilities, Zed provides macro recording and
+cursor management facilities."""
+url {
+  src: "https://github.com/ocaml-community/zed/archive/3.1.0.tar.gz"
+  checksum: "md5=51e8676ba972e5ad727633c161e404b1"
+}

--- a/package.json
+++ b/package.json
@@ -44,9 +44,13 @@
   "devDependencies": {
     "@opam/ocaml-lsp-server": "*",
     "@opam/ocamlformat": "0.19.0",
+    "@opam/utop": "*",
+    "@opam/menhir": "20210419",
+    "@esy-ocaml/rtop": "*",
     "@reason-native/rely": "*"
   },
   "resolutions": {
+    "@esy-ocaml/rtop": "ManasJayanth/reason:rtop.json#cb5afe1df701cfc92321f2123fce2dcad39a02aa",
     "ocaml": "github:esy-ocaml/ocaml#7af70dea28d218eb53bce7966e24dfe6762862ae",
     "@opam/httpaf": "github:anmonteiro/httpaf:httpaf.opam#559019829b7ed267a5b4b86aed1e7d7795214bcd",
     "@opam/httpaf-lwt": "github:anmonteiro/httpaf:httpaf-lwt.opam#559019829b7ed267a5b4b86aed1e7d7795214bcd",

--- a/tools/dtop.re
+++ b/tools/dtop.re
@@ -1,0 +1,29 @@
+let directive_string_fn = fn_name =>
+  switch (Hashtbl.find_opt(Toploop.directive_table, fn_name)) {
+  | Some(Toploop.Directive_string(fn)) => fn
+  | _ =>
+    Printf.printf(
+      "Custom top-level failed to load due to an internal error\nUnable to find directive %s\n",
+      fn_name,
+    );
+    exit(-1);
+  };
+
+let use_output = command => directive_string_fn("use_output", command);
+let load_dune_libs = () => use_output @@ "dune top | grep -v threads.cma";
+
+let () = load_dune_libs();
+let () = UTop.require(["reason.ocaml-migrate-parsetree", "menhirLib"]);
+
+let () =
+  try(Topdirs.dir_directory(Sys.getenv("OCAML_TOPLEVEL_PATH"))) {
+  | Not_found => ()
+  };
+
+let () = UTop.require(["reason.easy_format", "reason"]);
+
+let () = Reason_toploop.main();
+
+let () = Reason_utop.init_reason();
+
+let () = UTop_main.main();

--- a/tools/dune
+++ b/tools/dune
@@ -4,4 +4,3 @@
  (modes byte)
  (link_flags (-linkall))
  (libraries compiler-libs.toplevel utop reason rtop))
-

--- a/tools/dune
+++ b/tools/dune
@@ -1,0 +1,7 @@
+(executable
+ (name dtop)
+ (public_name dtop)
+ (modes byte)
+ (link_flags (-linkall))
+ (libraries compiler-libs.toplevel utop reason rtop))
+


### PR DESCRIPTION
`rtop` doesn't understand OCaml syntax emitted by `dune top` and needs a workaround - load the `cma` files first from the `use_output`, then activate the reason parsers in the REPL.

We could take this up in the Reason community and see if this can be fixed natively there.