### PR TITLE
ensure that side chain operations are checked

### DIFF
--- a/bin/sidecli.re
+++ b/bin/sidecli.re
@@ -151,15 +151,13 @@ let create_transaction = (sender_wallet_file, received_address, amount) => {
     let.ok wallet = load_wallet_file(sender_wallet_file);
 
     Ok(
-      Operation.self_sign_side(
-        ~key=wallet.priv_key,
-        Operation.Side_chain.make(
-          ~nonce=0l,
-          ~block_height=0L,
-          ~source=wallet.address,
-          ~amount,
-          ~kind=Transaction({destination: received_address}),
-        ),
+      Operation.Side_chain.sign(
+        ~secret=wallet.priv_key,
+        ~nonce=0l,
+        ~block_height=0L,
+        ~source=wallet.address,
+        ~amount,
+        ~kind=Transaction({destination: received_address}),
       ),
     );
   };

--- a/node/networking.re
+++ b/node/networking.re
@@ -142,7 +142,7 @@ module Register_uri = {
 
 module Operation_gossip = {
   [@deriving yojson]
-  type request = {operation: Operation.Side_chain.Self_signed.t};
+  type request = {operation: Operation.Side_chain.t};
   [@deriving yojson]
   type response = unit;
   let path = "/operation-gossip";

--- a/node/state.re
+++ b/node/state.re
@@ -14,7 +14,7 @@ module Uri_map = Map.Make(Uri);
 type t = {
   identity,
   data_folder: string,
-  pending_side_ops: list(Operation.Side_chain.Self_signed.t),
+  pending_side_ops: list(Operation.Side_chain.t),
   pending_main_ops: list(Operation.Main_chain.t),
   block_pool: Block_pool.t,
   protocol: Protocol.t,

--- a/node/state.rei
+++ b/node/state.rei
@@ -13,7 +13,7 @@ module Uri_map: Map.S with type key = Uri.t;
 type t = {
   identity,
   data_folder: string,
-  pending_side_ops: list(Operation.Side_chain.Self_signed.t),
+  pending_side_ops: list(Operation.Side_chain.t),
   pending_main_ops: list(Operation.Main_chain.t),
   block_pool: Block_pool.t,
   protocol: Protocol.t,

--- a/protocol/block.re
+++ b/protocol/block.re
@@ -20,7 +20,7 @@ type t = {
   // TODO: maybe it should be only for internal pagination and stuff like this
   block_height: int64,
   main_chain_ops: list(Main_chain.t),
-  side_chain_ops: list(Side_chain.Self_signed.t),
+  side_chain_ops: list(Side_chain.t),
 };
 
 let (hash, verify) = {
@@ -47,7 +47,7 @@ let (hash, verify) = {
         Address.t,
         int64,
         list(Main_chain.t),
-        list(Side_chain.Self_signed.t),
+        list(Side_chain.t),
       )
     ];
     let json =

--- a/protocol/block.rei
+++ b/protocol/block.rei
@@ -12,7 +12,7 @@ type t =
     author: Address.t,
     block_height: int64,
     main_chain_ops: list(Main_chain.t),
-    side_chain_ops: list(Side_chain.Self_signed.t),
+    side_chain_ops: list(Side_chain.t),
   };
 
 let sign: (~key: Address.key, t) => Signature.t;
@@ -23,6 +23,6 @@ let produce:
     ~state: State.t,
     ~author: Address.t,
     ~main_chain_ops: list(Main_chain.t),
-    ~side_chain_ops: list(Side_chain.Self_signed.t)
+    ~side_chain_ops: list(Side_chain.t)
   ) =>
   t;

--- a/protocol/operation.rei
+++ b/protocol/operation.rei
@@ -17,6 +17,7 @@ module Side_chain: {
   type t =
     pri {
       hash: BLAKE2B.t,
+      signature: Signature.t,
       nonce: int32,
       block_height: int64,
       source: Wallet.t,
@@ -24,8 +25,9 @@ module Side_chain: {
       kind,
     };
 
-  let make:
+  let sign:
     (
+      ~secret: Address.key,
       ~nonce: int32,
       ~block_height: int64,
       ~source: Wallet.t,
@@ -34,9 +36,15 @@ module Side_chain: {
     ) =>
     t;
 
-  // TODO: maybe use GADT for this?
-  module Self_signed: Signed.S with type data = t;
+  let verify:
+    (
+      ~hash: BLAKE2B.t,
+      ~signature: Signature.t,
+      ~nonce: int32,
+      ~block_height: int64,
+      ~source: Wallet.t,
+      ~amount: Amount.t,
+      ~kind: kind
+    ) =>
+    result(t, string);
 };
-
-let self_sign_side:
-  (~key: Address.key, Side_chain.t) => Side_chain.Self_signed.t;

--- a/protocol/protocol.re
+++ b/protocol/protocol.re
@@ -31,12 +31,11 @@ let apply_main_chain = (state, op) => {
 let maximum_old_block_height_operation = 60L;
 let maximum_stored_block_height = 75L; // we're dumb, lots, of off-by-one
 
-let apply_side_chain = (state: t, signed_operation) => {
+let apply_side_chain = (state: t, operation) => {
   open Operation.Side_chain;
   module Set = Operation_side_chain_set;
 
   // validate operation
-  let operation = signed_operation.Self_signed.data;
   let block_height = operation.block_height;
   if (block_height > state.block_height) {
     raise(Noop("block in the future"));
@@ -45,10 +44,6 @@ let apply_side_chain = (state: t, signed_operation) => {
   if (Int64.add(block_height, maximum_old_block_height_operation)
       < state.block_height) {
     raise(Noop("really old operation"));
-  };
-
-  if (!Wallet.pubkey_matches_wallet(signed_operation.key, operation.source)) {
-    raise(Noop("invalid key signed the operation"));
   };
 
   if (Set.mem(operation, state.included_operations)) {

--- a/tests/test_protocol.re
+++ b/tests/test_protocol.re
@@ -81,36 +81,32 @@ describe("protocol state", ({test, _}) => {
     "transaction",
     ~free_diff_a=-7,
     ~free_diff_b=7,
-    (state, (source, key), (destination, _)) => {
+    (state, (source, secret), (destination, _)) => {
     apply_side_chain(
       state,
-      Operation.self_sign_side(
-        ~key,
-        Operation.Side_chain.make(
-          ~nonce=0l,
-          ~block_height=0L,
-          ~source,
-          ~amount=Amount.of_int(7),
-          ~kind=Transaction({destination: destination}),
-        ),
+      Operation.Side_chain.sign(
+        ~secret,
+        ~nonce=0l,
+        ~block_height=0L,
+        ~source,
+        ~amount=Amount.of_int(7),
+        ~kind=Transaction({destination: destination}),
       ),
     )
   });
   test_failed_wallet_offset(
     "transaction",
     "not enough funds",
-    (state, (source, key), (destination, _)) =>
+    (state, (source, secret), (destination, _)) =>
     apply_side_chain(
       state,
-      Operation.self_sign_side(
-        ~key,
-        Operation.Side_chain.make(
-          ~nonce=0l,
-          ~block_height=0L,
-          ~source,
-          ~amount=Amount.of_int(501),
-          ~kind=Transaction({destination: destination}),
-        ),
+      Operation.Side_chain.sign(
+        ~secret,
+        ~nonce=0l,
+        ~block_height=0L,
+        ~source,
+        ~amount=Amount.of_int(501),
+        ~kind=Transaction({destination: destination}),
       ),
     )
   );


### PR DESCRIPTION
## Problem

This code was made in a couple of hours and was particularly brittle, and having two kinds of operations one checked and one not checked.

## This PR

The goal here is to simplify it and enforce the invariant that all side operations **must be signed by the source** of the money

