### PR TITLE
add tezos_hash to all main chain operations

### DIFF
--- a/protocol/operation.re
+++ b/protocol/operation.re
@@ -2,11 +2,21 @@ open Helpers;
 
 module Main_chain = {
   [@deriving (ord, yojson)]
-  type t =
+  type kind =
     // TODO: can a validator uses the same key in different nodes?
     // If so the ordering in the list must never use the same key two times in sequence
     | Add_validator(Validators.validator)
     | Remove_validator(Validators.validator);
+  [@deriving yojson]
+  type t = {
+    tezos_hash: BLAKE2B.t,
+    kind,
+  };
+  let compare = (a, b) => BLAKE2B.compare(a.tezos_hash, b.tezos_hash);
+
+  let make = (~tezos_hash, ~kind) => {
+    {tezos_hash, kind};
+  };
 };
 
 module Side_chain = {

--- a/protocol/operation.rei
+++ b/protocol/operation.rei
@@ -1,11 +1,20 @@
 open Helpers;
 module Main_chain: {
   [@deriving (ord, yojson)]
-  type t =
+  type kind =
     // TODO: can a validator uses the same key in different nodes?
     // If so the ordering in the list must never use the same key two times in sequence
     | Add_validator(Validators.validator)
     | Remove_validator(Validators.validator);
+
+  [@deriving (ord, yojson)]
+  type t =
+    pri {
+      tezos_hash: BLAKE2B.t,
+      kind,
+    };
+
+  let make: (~tezos_hash: BLAKE2B.t, ~kind: kind) => t;
 };
 
 module Side_chain: {

--- a/protocol/protocol.re
+++ b/protocol/protocol.re
@@ -14,7 +14,7 @@ module Operation = Operation;
 include State;
 let apply_main_chain = (state, op) => {
   Operation.Main_chain.(
-    switch (op) {
+    switch (op.kind) {
     // validators management
     | Add_validator(validator) =>
       let validators = Validators.add(validator, state.validators);

--- a/tests/test_protocol.re
+++ b/tests/test_protocol.re
@@ -121,21 +121,17 @@ describe("protocol state", ({test, _}) => {
     expect.option(Validators.current(validators)).toBeNone();
     expect.list(Validators.to_list(validators)).toBeEmpty();
     let new_validator = Validators.{address: Address.make_pubkey()};
+    let main_op = kind =>
+      Operation.Main_chain.make(~tezos_hash=Helpers.BLAKE2B.hash(""), ~kind);
     let state =
-      apply_main_chain(
-        state,
-        Operation.Main_chain.Add_validator(new_validator),
-      );
+      apply_main_chain(state, main_op(Add_validator(new_validator)));
     let validators = state.validators;
     expect.bool(Validators.current(validators) == Some(new_validator)).
       toBeTrue();
     expect.list(Validators.to_list(validators)).toEqual([new_validator]);
     // duplicated is a noop
     let state =
-      apply_main_chain(
-        state,
-        Operation.Main_chain.Add_validator(new_validator),
-      );
+      apply_main_chain(state, main_op(Add_validator(new_validator)));
     let validators = state.validators;
     expect.bool(Validators.current(validators) == Some(new_validator)).
       toBeTrue();
@@ -143,10 +139,7 @@ describe("protocol state", ({test, _}) => {
     // additional shouldn't move current
     let another_validator = Validators.{address: Address.make_pubkey()};
     let state =
-      apply_main_chain(
-        state,
-        Operation.Main_chain.Add_validator(another_validator),
-      );
+      apply_main_chain(state, main_op(Add_validator(another_validator)));
     let validators = state.validators;
     expect.bool(Validators.current(validators) == Some(new_validator)).
       toBeTrue();
@@ -165,10 +158,7 @@ describe("protocol state", ({test, _}) => {
     // ]);
     // remove current validator
     let state =
-      apply_main_chain(
-        state,
-        Operation.Main_chain.Remove_validator(another_validator),
-      );
+      apply_main_chain(state, main_op(Remove_validator(another_validator)));
     let validators = state.validators;
     expect.bool(Validators.current(validators) == Some(new_validator)).
       toBeTrue();
@@ -181,10 +171,7 @@ describe("protocol state", ({test, _}) => {
     // expect.list(Validators.validators(validators)).toEqual([new_validator]);
     // remove all validators
     let state =
-      apply_main_chain(
-        state,
-        Operation.Main_chain.Remove_validator(new_validator),
-      );
+      apply_main_chain(state, main_op(Remove_validator(new_validator)));
     let validators = state.validators;
     expect.option(Validators.current(validators)).toBeNone();
     expect.list(Validators.to_list(validators)).toBeEmpty();


### PR DESCRIPTION
## Problem

Currently main chain operations have no identifier shared with tezos, so we cannot ensure that an operation already happened.

## This PR

It is a temporary fix, it adds the tezos_hash to allow main chain operations to be properly indexed.