### PR TITLE
add incremental patricia tree

### DIFF
--- a/helpers/BLAKE2B.re
+++ b/helpers/BLAKE2B.re
@@ -16,6 +16,8 @@ module Make =
 
          let hash: string => t;
          let verify: (~hash: t, string) => bool;
+
+         let both: (t, t) => t;
        } => {
   include P;
   include Digestif.Make_BLAKE2B({
@@ -38,6 +40,8 @@ module Make =
 
   let hash = data => digest_string(data);
   let verify = (~hash as expected_hash, data) => expected_hash == hash(data);
+
+  let both = (a, b) => hash(to_raw_string(a) ++ to_raw_string(b));
 };
 
 module BLAKE2B_20 =

--- a/helpers/helpers.re
+++ b/helpers/helpers.re
@@ -138,3 +138,4 @@ module Int64_map =
 
 module BLAKE2B = BLAKE2B;
 module BLAKE2B_20 = BLAKE2B.BLAKE2B_20;
+module Incremental_patricia = Incremental_patricia;

--- a/helpers/incremental_patricia.re
+++ b/helpers/incremental_patricia.re
@@ -1,0 +1,103 @@
+module Make =
+       (
+         V: {
+           [@deriving yojson]
+           type t;
+           let hash: t => BLAKE2B.t;
+         },
+       ) => {
+  [@deriving yojson]
+  type value = V.t;
+  [@deriving yojson]
+  type key = int;
+  [@deriving yojson]
+  type tree =
+    | Empty
+    | Leaf({
+        value,
+        hash: BLAKE2B.t,
+      })
+    | Node({
+        left: tree,
+        hash: BLAKE2B.t,
+        right: tree,
+      });
+  [@deriving yojson]
+  type t = {
+    tree,
+    top_bit: key,
+    last_key: key,
+  };
+
+  let is_set = (bit, number) => 1 lsl bit land number != 0;
+
+  let empty_hash = BLAKE2B.hash("");
+  let hash_of_t =
+    fun
+    | Empty => empty_hash
+    | Leaf({hash, _})
+    | Node({hash, _}) => hash;
+  let rec find = (bit, proofs, key, t) =>
+    switch (t) {
+    | Empty => None
+    | Leaf({value, _}) => Some((List.rev(proofs), value))
+    | Node({left, right, _}) =>
+      let t = is_set(bit, key) ? right : left;
+      find(
+        bit - 1,
+        [(hash_of_t(left), hash_of_t(right)), ...proofs],
+        key,
+        t,
+      );
+    };
+
+  let find = (key, t) =>
+    if (key >= 0 && key <= t.last_key) {
+      find(t.top_bit - 1, [], key, t.tree);
+    } else {
+      None;
+    };
+
+  let node = (left, right) => {
+    let hash = BLAKE2B.both(hash_of_t(left), hash_of_t(right));
+    Node({left, hash, right});
+  };
+
+  let rec empty = n =>
+    if (n == 0) {
+      Empty;
+    } else {
+      let tree = empty(n - 1);
+      node(tree, tree);
+    };
+
+  // TODO: maybe add should also return the full proof?
+  let add = (f, t) => {
+    let rec add = (bit, key, value, t) =>
+      switch (bit, t) {
+      | ((-1), Empty) => Leaf({value, hash: V.hash(value)})
+      | (_, Node({left, right, _})) =>
+        is_set(bit, key)
+          ? node(left, add(bit - 1, key, value, right))
+          : node(add(bit - 1, key, value, left), right)
+      | _ => assert(false)
+      };
+
+    let key = t.last_key + 1;
+    let value = f(key);
+    let increase_top_bit = key lsr t.top_bit;
+    let top_bit = t.top_bit + increase_top_bit;
+    let tree =
+      if (increase_top_bit == 1) {
+        let right = empty(top_bit - 1);
+        node(t.tree, right);
+      } else {
+        t.tree;
+      };
+
+    let tree = add(top_bit - 1, key, value, tree);
+    ({tree, top_bit, last_key: key}, value);
+  };
+  let empty = {top_bit: 0, tree: Empty, last_key: (-1)};
+  let hash = t => hash_of_t(t.tree);
+};

--- a/helpers/incremental_patricia.rei
+++ b/helpers/incremental_patricia.rei
@@ -1,0 +1,19 @@
+module Make:
+  (
+    V: {
+      [@deriving yojson]
+      type t;
+      let hash: t => BLAKE2B.t;
+    },
+  ) =>
+   {
+    type value = V.t;
+    type key = int;
+    [@deriving yojson]
+    type t;
+
+    let empty: t;
+    let hash: t => BLAKE2B.t;
+    let add: (key => value, t) => (t, value);
+    let find: (key, t) => option((list((BLAKE2B.t, BLAKE2B.t)), value));
+  };

--- a/tests/dune
+++ b/tests/dune
@@ -4,7 +4,9 @@
   (:standard \ Test_runner))
  (library_flags
   (-linkall -g))
- (libraries rely.lib tezos_interop protocol node mirage-crypto-rng.unix))
+ (libraries rely.lib tezos_interop protocol node mirage-crypto-rng.unix)
+ (preprocess
+  (pps ppx_deriving_yojson)))
 
 (executable
  (name Test_runner)

--- a/tests/test_incremental_patricia.re
+++ b/tests/test_incremental_patricia.re
@@ -1,0 +1,56 @@
+open Setup;
+open Helpers;
+
+module M = {
+  [@deriving yojson]
+  type t = {
+    key: int,
+    hash: BLAKE2B.t,
+  };
+  let hash = t => t.hash;
+  let make = key => {key, hash: BLAKE2B.hash(string_of_int(key))};
+};
+open M;
+open Incremental_patricia.Make(M);
+
+describe("incremental Patricia", ({test, _}) => {
+  test("add and find", ({expect, _}) => {
+    let add_and_test = (tree, ()) => {
+      let (tree, value) = add(make, tree);
+      let (_, stored_value) = find(value.key, tree) |> Option.get;
+      expect.equal(value, stored_value);
+      tree;
+    };
+    let size = 1;
+    let tree =
+      List.init(size, _ => ()) |> List.fold_left(add_and_test, empty);
+    let _ = List.init(size, n => expect.option(find(n, tree)).toBeSome());
+    ();
+  });
+  test("hash", ({expect, _}) => {
+    let tree = empty;
+    let (tree, a) = add(make, tree);
+
+    expect.equal(hash(tree), a.hash);
+    let (tree, b) = add(make, tree);
+    expect.equal(hash(tree), BLAKE2B.both(a.hash, b.hash));
+
+    let (tree, c) = add(make, tree);
+    expect.equal(
+      hash(tree),
+      BLAKE2B.both(
+        BLAKE2B.both(a.hash, b.hash),
+        BLAKE2B.both(c.hash, hash(empty)),
+      ),
+    );
+
+    let (tree, d) = add(make, tree);
+    expect.equal(
+      hash(tree),
+      BLAKE2B.both(
+        BLAKE2B.both(a.hash, b.hash),
+        BLAKE2B.both(c.hash, d.hash),
+      ),
+    );
+  });
+});


### PR DESCRIPTION
## Problem

To validate data on Tezos main chain during withdraws the user needs a way to provide a proof that he did burn the money on the sidechain.

## Solution

We use a binary radix tree, where the key is always an incremental int, with this every money burnt will receive an id back that can be used to construct the proof.

## Related issues

- #34