### PR TITLE
support ticket on tezos_interop

### DIFF
--- a/tests/test_tezos_interop.re
+++ b/tests/test_tezos_interop.re
@@ -245,6 +245,39 @@ describe("address", ({test, _}) => {
     expect.option(of_string("tz1LzCSmZHG3jDvqxA8SG8WqbrJ9wz5eUCL")).toBeNone()
   });
 });
+describe("ticket", ({test, _}) => {
+  open Ticket;
+
+  let kt1 = Address.Originated(some_contract_hash);
+  let ticket = {ticketer: kt1, data: Bytes.of_string("a")};
+  test("to_string", ({expect, _}) => {
+    expect.string(to_string(ticket)).toEqual(
+      {|(Pair "KT1Dbav7SYrJFpd3bT7sVFDS9MPp4F5gABTc" 0x61)|},
+    )
+  });
+  test("of_string", ({expect, _}) => {
+    expect.option(
+      of_string({|(Pair "KT1Dbav7SYrJFpd3bT7sVFDS9MPp4F5gABTc" 0x61)|}),
+    ).
+      toBe(
+      ~equals=(==),
+      Some(ticket),
+    )
+  });
+
+  test("invalid address", ({expect, _}) => {
+    expect.option(
+      of_string({|(Pair "BT1Dbav7SYrJFpd3bT7sVFDS9MPp4F5gABTc" 0x61)|}),
+    ).
+      toBeNone()
+  });
+  test("invalid bytes", ({expect, _}) => {
+    expect.option(
+      of_string({|(Pair "BT1Dbav7SYrJFpd3bT7sVFDS9MPp4F5gABTc" 0x6Z)|}),
+    ).
+      toBeNone()
+  });
+});
 describe("pack", ({test, _}) => {
   open Pack;
 

--- a/tezos_interop/tezos_interop.rei
+++ b/tezos_interop/tezos_interop.rei
@@ -15,6 +15,7 @@ module Key_hash: {
     | Ed25519(Helpers.BLAKE2B_20.t);
 
   let of_key: Key.t => t;
+
   let to_string: t => string;
   let of_string: string => option(t);
 };
@@ -53,6 +54,15 @@ module Address: {
   let of_string: string => option(t);
 };
 
+module Ticket: {
+  type t = {
+    ticketer: Address.t,
+    data: bytes,
+  };
+
+  let to_string: t => string;
+  let of_string: string => option(t);
+};
 module Pack: {
   type t;
 


### PR DESCRIPTION
## Problem

We need to be able to receive and store tickets(ticketer and data) in the sidechain coming from Tezos for deposit and withdraw.

## Solution

Add a proper support for tickets in Tezos_interop, this duplicates Tezos logic to sidechain to avoid having a hard dependency on tezos-crypto the logic can be tracked from:

https://gitlab.com/tezos/tezos/-/blob/master/src/proto_alpha/lib_protocol/script_ir_translator.ml#L5850

## Related Issues

- #34
