### PR TITLE
Uses esy shell in .tmuxinator config

### DIFF
--- a/.tmuxinator.yml
+++ b/.tmuxinator.yml
@@ -22,7 +22,7 @@ root: ./data
 # on_project_stop: command
 
 # Runs in each window and pane before window/pane specific commands. Useful for setting up interpreter versions.
-# pre_window: rbenv shell 2.0.0-p247
+pre_window: esy shell
 
 # Pass command line options to tmux. Useful for specifying a different tmux.conf.
 # tmux_options: -f ~/.tmux.mac.conf


### PR DESCRIPTION
Use pre_window field in the config to reliably set up the environment
in which cur__* variables are always present in all tmux panes.