### PR TITLE
make a library for files

### DIFF
--- a/bin/dune
+++ b/bin/dune
@@ -7,7 +7,13 @@
 
 (executable
  (name sidecli)
- (libraries node mirage-crypto-ec mirage-crypto-rng.unix helpers cmdliner)
+ (libraries
+  node
+  files
+  mirage-crypto-ec
+  mirage-crypto-rng.unix
+  helpers
+  cmdliner)
  (modules Sidecli)
  (public_name sidecli)
  (preprocess

--- a/bin/dune
+++ b/bin/dune
@@ -12,3 +12,10 @@
  (public_name sidecli)
  (preprocess
   (pps ppx_deriving_yojson)))
+
+(library
+ (name files)
+ (modules Files)
+ (libraries lwt lwt.unix node)
+ (preprocess
+  (pps ppx_deriving_yojson)))

--- a/bin/dune
+++ b/bin/dune
@@ -1,6 +1,6 @@
 (executable
  (name http_server)
- (libraries opium node mirage-crypto-ec mirage-crypto-rng.unix helpers)
+ (libraries opium files node mirage-crypto-ec mirage-crypto-rng.unix helpers)
  (modules Http_server)
  (preprocess
   (pps ppx_deriving.show ppx_deriving_yojson)))

--- a/bin/files.re
+++ b/bin/files.re
@@ -1,0 +1,49 @@
+open Helpers;
+open Node;
+open State;
+open Protocol;
+
+exception Invalid_json(string);
+let read_json = (of_yojson, ~file) => {
+  let.await string = Lwt_io.with_file(~mode=Input, file, Lwt_io.read);
+  let json = Yojson.Safe.from_string(string);
+  switch (of_yojson(json)) {
+  | Ok(data) => await(data)
+  | Error(error) => raise(Invalid_json(error))
+  };
+};
+let write_json = (to_yojson, data, ~file) =>
+  Lwt_io.with_file(~mode=Output, file, oc =>
+    Lwt_io.write(oc, Yojson.Safe.pretty_to_string(to_yojson(data)))
+  );
+module Identity = {
+  let read = read_json(identity_of_yojson);
+  let write = write_json(identity_to_yojson);
+};
+module Wallet = {
+  [@deriving yojson]
+  type t = {
+    address: Wallet.t,
+    priv_key: Address.key,
+  };
+  let read = read_json(of_yojson);
+  let write = write_json(to_yojson);
+};
+module Validators = {
+  [@deriving yojson]
+  type t = {
+    address: Address.t,
+    uri: Uri.t,
+  };
+  let read =
+    read_json(json => {
+      let.ok validators = [%of_yojson: list(t)](json);
+      Ok(List.map(({address, uri}) => (address, uri), validators));
+    });
+  let write =
+    write_json(validators =>
+      validators
+      |> List.map(((address, uri)) => {address, uri})
+      |> [%to_yojson: list(t)]
+    );
+};

--- a/bin/files.rei
+++ b/bin/files.rei
@@ -1,0 +1,24 @@
+open Node;
+open State;
+open Protocol;
+
+exception Invalid_json(string);
+
+module Identity: {
+  let read: (~file: string) => Lwt.t(identity);
+  let write: (identity, ~file: string) => Lwt.t(unit);
+};
+
+module Wallet: {
+  type t = {
+    address: Wallet.t,
+    priv_key: Address.key,
+  };
+  let read: (~file: string) => Lwt.t(t);
+  let write: (t, ~file: string) => Lwt.t(unit);
+};
+
+module Validators: {
+  let read: (~file: string) => Lwt.t(list((Address.t, Uri.t)));
+  let write: (list((Address.t, Uri.t)), ~file: string) => Lwt.t(unit);
+};


### PR DESCRIPTION
## Depends

- [x] #44 

## Problem

We've been duplicating logic for a while to handle files, namely `identity.json` and `validators.json`, this is getting quite messy especially when adding new files.

## Solution

I made a library for file formats which currently sits as part of `bin`, this is not ideal but it solves the duplicated code problem without too many changes on the project structure.