### PR TITLE
Set block level in create-transaction command

### DIFF
--- a/bin/http_server.re
+++ b/bin/http_server.re
@@ -47,12 +47,13 @@ let handle_request =
         let response = E.response_to_yojson(response);
         await(Response.of_json(~status=`OK, response));
       | Error(err) =>
-        switch(err) {
-        | `Not_a_json => print_endline("Invalid json");
-        | `Not_a_valid_request(err) => print_endline("Invalid request:"  ++ err);
-          | _ => print_endline("unhandled");
-        }
-        await(Response.make(~status=`Internal_server_error, ()))
+        switch (err) {
+        | `Not_a_json => print_endline("Invalid json")
+        | `Not_a_valid_request(err) =>
+          print_endline("Invalid request:" ++ err)
+        | _ => print_endline("unhandled")
+        };
+        await(Response.make(~status=`Internal_server_error, ()));
       };
     },
   );
@@ -103,7 +104,7 @@ let handle_block_by_hash =
 
 let handle_block_level =
   handle_request((module Block_level), (_update_state, _request) => {
-    Ok({ level : Flows.find_block_level(Server.get_state()) })
+    Ok({level: Flows.find_block_level(Server.get_state())})
   });
 
 let handle_protocol_snapshot =

--- a/node/flows.re
+++ b/node/flows.re
@@ -314,7 +314,7 @@ let received_operation =
 let find_block_by_hash = (state, hash) =>
   Block_pool.find_block(~hash, state.Node.block_pool);
 
-let find_block_level = (state) => {
+let find_block_level = state => {
   state.State.protocol.block_height;
 };
 

--- a/node/flows.re
+++ b/node/flows.re
@@ -314,6 +314,10 @@ let received_operation =
 let find_block_by_hash = (state, hash) =>
   Block_pool.find_block(~hash, state.Node.block_pool);
 
+let find_block_level = (state) => {
+  state.State.protocol.block_height;
+};
+
 let request_nonce = (state, update_state, uri) => {
   // TODO: nonce size, think about this, 32 is just magic because of SHA256
   let nonce = Mirage_crypto_rng.generate(32) |> Cstruct.to_string;

--- a/node/networking.re
+++ b/node/networking.re
@@ -110,7 +110,7 @@ module Block_level = {
   [@deriving yojson]
   type request = unit;
   [@deriving yojson]
-  type response = { level: int64 };
+  type response = {level: int64};
   let path = "/block-level";
 };
 

--- a/node/networking.re
+++ b/node/networking.re
@@ -105,6 +105,15 @@ module Block_by_hash_spec = {
   let path = "/block-by-hash";
 };
 
+/* Endpoint to return latest block's level */
+module Block_level = {
+  [@deriving yojson]
+  type request = unit;
+  [@deriving yojson]
+  type response = { level: int64 };
+  let path = "/block-level";
+};
+
 module Protocol_snapshot = {
   [@deriving yojson]
   type request = unit;

--- a/node/networking.re
+++ b/node/networking.re
@@ -173,6 +173,7 @@ module Data_to_smart_contract = {
 };
 
 let request_block_by_hash = request((module Block_by_hash_spec));
+let request_block_level = request((module Block_level));
 let request_protocol_snapshot = request((module Protocol_snapshot));
 let request_nonce = request((module Request_nonce));
 let request_register_uri = request((module Register_uri));


### PR DESCRIPTION
**Problem**
To prevent replay attacks, `create-transaction` command must stamp the transaction requests to the node with the block level at which the transaction is expected to be baked.

**Solution**
This PR adds a `/block-level` endpoint to query the current block level and use it while signing the transaction operation.