### PR TITLE
add tezos_interop context files

### DIFF
--- a/bin/files.re
+++ b/bin/files.re
@@ -47,3 +47,36 @@ module Validators = {
       |> [%to_yojson: list(t)]
     );
 };
+
+module Interop_context = {
+  module Address = {
+    include Tezos_interop.Address;
+    let of_yojson =
+      fun
+      | `String(string) =>
+        of_string(string) |> Option.to_result(~none="invalid address")
+      | _ => Error("expected a string");
+    let to_yojson = t => `String(to_string(t));
+  };
+  module Secret = {
+    include Tezos_interop.Secret;
+    let of_yojson =
+      fun
+      | `String(string) =>
+        of_string(string) |> Option.to_result(~none="invalid secret")
+      | _ => Error("expected a string");
+    let to_yojson = t => `String(to_string(t));
+  };
+
+  [@deriving yojson]
+  type t =
+    Tezos_interop.Context.t = {
+      rpc_node: Uri.t,
+      secret: Secret.t,
+      consensus_contract: Address.t,
+      required_confirmations: int,
+    };
+
+  let read = read_json(of_yojson);
+  let write = write_json(to_yojson);
+};

--- a/bin/files.rei
+++ b/bin/files.rei
@@ -22,3 +22,7 @@ module Validators: {
   let read: (~file: string) => Lwt.t(list((Address.t, Uri.t)));
   let write: (list((Address.t, Uri.t)), ~file: string) => Lwt.t(unit);
 };
+module Interop_context: {
+  let read: (~file: string) => Lwt.t(Tezos_interop.Context.t);
+  let write: (Tezos_interop.Context.t, ~file: string) => Lwt.t(unit);
+};

--- a/tezos_interop/tezos_interop.re
+++ b/tezos_interop/tezos_interop.re
@@ -373,6 +373,15 @@ module Pack = {
     |> Bytes.cat(Bytes.of_string("\005"));
 };
 
+module Context = {
+  type t = {
+    rpc_node: Uri.t,
+    secret: Secret.t,
+    consensus_contract: Address.t,
+    required_confirmations: int,
+  };
+};
+
 module Consensus = {
   open Pack;
   let hash_validators = validators =>

--- a/tezos_interop/tezos_interop.rei
+++ b/tezos_interop/tezos_interop.rei
@@ -77,6 +77,14 @@ module Pack: {
   let to_bytes: t => bytes;
 };
 
+module Context: {
+  type t = {
+    rpc_node: Uri.t,
+    secret: Secret.t,
+    consensus_contract: Address.t,
+    required_confirmations: int,
+  };
+};
 module Consensus: {
   let hash_validators: list(Key.t) => BLAKE2B.t;
   let hash_block:


### PR DESCRIPTION
## Depends

- [x] #63

## Problem

To solve #61 we need to have some information about how to talk to Tezos, which rpc, consensus contract, validators and how many confirmations needed.

## Solution

This PR adds a file where the required data can be parametrized externally.

## Related Issues

- #61