### PR TITLE
add tickets to operations

### DIFF
--- a/helpers/helpers.re
+++ b/helpers/helpers.re
@@ -139,3 +139,9 @@ module Int64_map =
 module BLAKE2B = BLAKE2B;
 module BLAKE2B_20 = BLAKE2B.BLAKE2B_20;
 module Incremental_patricia = Incremental_patricia;
+
+let with_yojson_string = (from, to_) => (
+  (json: Yojson.Safe.t) =>
+    [%of_yojson: string](json) |> Result.bind(_, from),
+  (t) => (`String(to_(t)): Yojson.Safe.t),
+);

--- a/protocol/ledger.rei
+++ b/protocol/ledger.rei
@@ -1,10 +1,10 @@
 [@deriving yojson]
 type t;
 let empty: t;
-let balance: (Wallet.t, t) => Amount.t;
+let balance: (Wallet.t, Ticket.t, t) => Amount.t;
 let transfer:
-  (~source: Wallet.t, ~destination: Wallet.t, Amount.t, t) =>
+  (~source: Wallet.t, ~destination: Wallet.t, Amount.t, Ticket.t, t) =>
   result(t, [> | `Not_enough_funds]);
 
 // on chain ops
-let deposit: (Wallet.t, Amount.t, t) => t;
+let deposit: (Wallet.t, Amount.t, Ticket.t, t) => t;

--- a/protocol/operation.rei
+++ b/protocol/operation.rei
@@ -31,6 +31,7 @@ module Side_chain: {
       block_height: int64,
       source: Wallet.t,
       amount: Amount.t,
+      ticket: Ticket.t,
       kind,
     };
 
@@ -41,6 +42,7 @@ module Side_chain: {
       ~block_height: int64,
       ~source: Wallet.t,
       ~amount: Amount.t,
+      ~ticket: Ticket.t,
       ~kind: kind
     ) =>
     t;
@@ -53,6 +55,7 @@ module Side_chain: {
       ~block_height: int64,
       ~source: Wallet.t,
       ~amount: Amount.t,
+      ~ticket: Ticket.t,
       ~kind: kind
     ) =>
     result(t, string);

--- a/protocol/protocol.re
+++ b/protocol/protocol.re
@@ -53,11 +53,11 @@ let apply_side_chain = (state: t, operation) => {
   // apply operation
   let included_operations = Set.add(operation, state.included_operations);
 
-  let {source, amount, _} = operation;
+  let {source, amount, ticket, _} = operation;
   let ledger =
     switch (operation.kind) {
     | Transaction({destination}) =>
-      Ledger.transfer(~source, ~destination, amount, state.ledger)
+      Ledger.transfer(~source, ~destination, amount, ticket, state.ledger)
     };
   let ledger =
     switch (ledger) {

--- a/protocol/ticket.re
+++ b/protocol/ticket.re
@@ -1,0 +1,28 @@
+open Tezos_interop;
+
+// TODO: I feel uneasy about this module
+module Address = {
+  include Address;
+  let with_yojson_string = (name, of_string, to_string) =>
+    Helpers.with_yojson_string(
+      string =>
+        of_string(string) |> Option.to_result(~none="invalid " ++ name),
+      to_string,
+    );
+  let (of_yojson, to_yojson) =
+    with_yojson_string("address", of_string, to_string);
+};
+
+[@deriving yojson]
+type t =
+  Ticket.t = {
+    ticketer: Address.t,
+    data: bytes,
+  };
+
+// TODO: should we expose to_yojson here?
+let compare = (a, b) => {
+  let to_string = a =>
+    Bytes.to_string(a.data) ++ Tezos_interop.Address.to_string(b.ticketer);
+  String.compare(to_string(a), to_string(b));
+};

--- a/protocol/ticket.rei
+++ b/protocol/ticket.rei
@@ -1,0 +1,7 @@
+// TODO: at least do a proper abstraction here
+[@deriving (ord, yojson)]
+type t =
+  Tezos_interop.Ticket.t = {
+    ticketer: Tezos_interop.Address.t,
+    data: bytes,
+  };

--- a/tests/test_ledger.re
+++ b/tests/test_ledger.re
@@ -1,80 +1,142 @@
 open Setup;
+open Helpers;
 open Protocol;
 open Ledger;
 
 describe("ledger", ({test, _}) => {
   // TODO: maybe have a "total amount" function to ensure invariant?
+  let make_ticket = () => {
+    open Tezos_interop;
+    let random_hash =
+      Mirage_crypto_rng.generate(20)
+      |> Cstruct.to_string
+      |> BLAKE2B_20.of_raw_string
+      |> Option.get;
+    let ticketer = Address.Originated(random_hash);
+    let data = Mirage_crypto_rng.generate(256) |> Cstruct.to_bytes;
+    Ticket.{ticketer, data};
+  };
+  let _ = make_ticket();
   let make_wallet = () => {
     open Mirage_crypto_ec;
     let (_key, address) = Ed25519.generate();
     Wallet.of_address(address);
   };
   let setup_two = () => {
+    let t1 = make_ticket();
+    let t2 = make_ticket();
+
     let a = make_wallet();
     let b = make_wallet();
     let t =
       empty
-      |> deposit(a, Amount.of_int(100))
-      |> deposit(b, Amount.of_int(200));
-    (t, a, b);
+      |> deposit(a, Amount.of_int(100), t1)
+      |> deposit(a, Amount.of_int(300), t2)
+      |> deposit(b, Amount.of_int(200), t1)
+      |> deposit(b, Amount.of_int(400), t2);
+    (t, (t1, t2), (a, b));
   };
-  test("balance", ({expect, _}) => {
-    let (t, a, b) = setup_two();
-    expect.equal(balance(a, t), Amount.of_int(100));
-    expect.equal(balance(b, t), Amount.of_int(200));
+  let test = (name, f) =>
+    test(
+      name,
+      ({expect, _}) => {
+        let expect_balance = (address, ticket, expected, t) => {
+          expect.equal(
+            Amount.of_int(expected),
+            balance(address, ticket, t),
+          );
+        };
+        f(expect, expect_balance);
+      },
+    );
+  test("balance", (_, expect_balance) => {
+    let (t, (t1, t2), (a, b)) = setup_two();
+    expect_balance(a, t1, 100, t);
+    expect_balance(a, t2, 300, t);
+    expect_balance(b, t1, 200, t);
+    expect_balance(b, t2, 400, t);
 
-    expect.equal(balance(make_wallet(), t), Amount.zero);
+    expect_balance(make_wallet(), t1, 0, t);
+    expect_balance(make_wallet(), t2, 0, t);
+    expect_balance(a, make_ticket(), 0, t);
+    expect_balance(b, make_ticket(), 0, t);
   });
-  test("transfer", ({expect, _}) => {
-    let (t, a, b) = setup_two();
+  test("transfer", (expect, expect_balance) => {
+    let (t, (t1, t2), (a, b)) = setup_two();
     let c = make_wallet();
 
-    let t = transfer(~source=a, ~destination=b, Amount.of_int(1), t);
+    let t = transfer(~source=a, ~destination=b, Amount.of_int(1), t1, t);
     expect.result(t).toBeOk();
     let t = Result.get_ok(t);
-    expect.equal(balance(a, t), Amount.of_int(99));
-    expect.equal(balance(b, t), Amount.of_int(201));
-    expect.equal(balance(c, t), Amount.of_int(0));
+    expect_balance(a, t1, 99, t);
+    expect_balance(a, t2, 300, t);
+    expect_balance(b, t1, 201, t);
+    expect_balance(b, t2, 400, t);
+    expect_balance(c, t1, 0, t);
+    expect_balance(c, t2, 0, t);
 
-    let t = transfer(~source=b, ~destination=a, Amount.of_int(3), t);
+    let t = transfer(~source=b, ~destination=a, Amount.of_int(3), t2, t);
     expect.result(t).toBeOk();
     let t = Result.get_ok(t);
-    expect.equal(balance(a, t), Amount.of_int(102));
-    expect.equal(balance(b, t), Amount.of_int(198));
-    expect.equal(balance(c, t), Amount.of_int(0));
+    expect_balance(a, t1, 99, t);
+    expect_balance(a, t2, 303, t);
+    expect_balance(b, t1, 201, t);
+    expect_balance(b, t2, 397, t);
+    expect_balance(c, t1, 0, t);
+    expect_balance(c, t2, 0, t);
 
-    let t = transfer(~source=b, ~destination=c, Amount.of_int(5), t);
+    let t = transfer(~source=b, ~destination=c, Amount.of_int(5), t2, t);
     expect.result(t).toBeOk();
     let t = Result.get_ok(t);
-    expect.equal(balance(a, t), Amount.of_int(102));
-    expect.equal(balance(b, t), Amount.of_int(193));
-    expect.equal(balance(c, t), Amount.of_int(5));
+    expect_balance(a, t1, 99, t);
+    expect_balance(a, t2, 303, t);
+    expect_balance(b, t1, 201, t);
+    expect_balance(b, t2, 392, t);
+    expect_balance(c, t1, 0, t);
+    expect_balance(c, t2, 5, t);
+
+    let t = transfer(~source=a, ~destination=c, Amount.of_int(99), t1, t);
+    expect.result(t).toBeOk();
+    let t = Result.get_ok(t);
+    expect_balance(a, t1, 0, t);
+    expect_balance(a, t2, 303, t);
+    expect_balance(b, t1, 201, t);
+    expect_balance(b, t2, 392, t);
+    expect_balance(c, t1, 99, t);
+    expect_balance(c, t2, 5, t);
 
     {
-      let t = transfer(~source=b, ~destination=c, Amount.of_int(194), t);
+      let t = transfer(~source=b, ~destination=c, Amount.of_int(202), t1, t);
       expect.result(t).toBeError();
       expect.equal(Result.get_error(t), `Not_enough_funds);
     };
     {
       let d = make_wallet();
-      let t = transfer(~source=d, ~destination=c, Amount.of_int(1), t);
+      let t = transfer(~source=d, ~destination=c, Amount.of_int(1), t2, t);
+      expect.result(t).toBeError();
+      expect.equal(Result.get_error(t), `Not_enough_funds);
+    };
+    {
+      let t3 = make_ticket();
+      let t = transfer(~source=a, ~destination=b, Amount.of_int(1), t3, t);
       expect.result(t).toBeError();
       expect.equal(Result.get_error(t), `Not_enough_funds);
     };
     ();
   });
-  test("deposit", ({expect, _}) => {
-    let (t, a, b) = setup_two();
+  test("deposit", (_, expect_balance) => {
+    let (t, (t1, t2), (a, b)) = setup_two();
 
-    expect.equal(balance(a, t), Amount.of_int(100));
-    expect.equal(balance(b, t), Amount.of_int(200));
+    let t = deposit(a, Amount.of_int(123), t1, t);
+    expect_balance(a, t1, 223, t);
+    expect_balance(a, t2, 300, t);
+    expect_balance(b, t1, 200, t);
+    expect_balance(b, t2, 400, t);
 
-    let t = deposit(a, Amount.of_int(123), t);
-    expect.equal(balance(a, t), Amount.of_int(223));
-    expect.equal(balance(b, t), Amount.of_int(200));
-
-    let t = deposit(b, Amount.of_int(456), t);
-    expect.equal(balance(a, t), Amount.of_int(223));
-    expect.equal(balance(b, t), Amount.of_int(656));
+    let t = deposit(b, Amount.of_int(456), t2, t);
+    expect_balance(a, t1, 223, t);
+    expect_balance(a, t2, 300, t);
+    expect_balance(b, t1, 200, t);
+    expect_balance(b, t2, 856, t);
   });
 });


### PR DESCRIPTION
## Problem

Users should be able to operate on tickets.

## Solution

This is solved through adding tickets to the ledger and to Transaction operation, because of this essentially the key for a ledger is a tuple between the `ticket` and wallet `address`.

## Related Issues

- #34 