### PR TITLE
add handles hash to root hash

### DIFF
--- a/tests/test_tezos_interop.re
+++ b/tests/test_tezos_interop.re
@@ -372,7 +372,7 @@ describe("consensus", ({test, _}) => {
       );
     let hash = BLAKE2B.to_string(hash);
     expect.string(hash).toEqual(
-      "58b39faab167d45a69a0cf126bade7fd23932b2c48684adfbd164281ca2cc5ff",
+      "23cdb9e9ffef6dd17553b622af0c043f544daa18430dff295d04a9d46b3e5267",
     );
   });
 });

--- a/tezos_interop/consensus.mligo
+++ b/tezos_interop/consensus.mligo
@@ -11,6 +11,7 @@ type root_hash_storage = {
   current_block_hash: blake2b;
   current_block_height: int;
   current_state_hash: blake2b;
+  current_handles_hash: blake2b;
   current_validators: validators;
 }
 
@@ -22,6 +23,7 @@ type root_hash_action = {
   block_payload_hash: blake2b;
 
   state_hash: blake2b;
+  handles_hash: blake2b;
   (* TODO: performance, can this blown up? *)
   validators: validators;
 
@@ -34,6 +36,7 @@ type block_hash_structure = {
   block_height: int;
   block_payload_hash: blake2b;
   state_hash: blake2b;
+  handles_hash: blake2b;
   validators_hash: blake2b;
 }
 
@@ -54,6 +57,7 @@ let root_hash_check_hash (root_hash_update: root_hash_action) =
     block_height = root_hash_update.block_height;
     block_payload_hash = root_hash_update.block_payload_hash;
     state_hash = root_hash_update.state_hash;
+    handles_hash = root_hash_update.handles_hash;
     (* TODO: should we do pack of list? *)
     validators_hash = Crypto.blake2b (Bytes.pack root_hash_update.validators)
   } in
@@ -101,6 +105,7 @@ let root_hash_main
     let block_hash = root_hash_update.block_hash in
     let block_height = root_hash_update.block_height in
     let state_hash = root_hash_update.state_hash in
+    let handles_hash = root_hash_update.handles_hash in
     let validators = root_hash_update.validators in
     let signatures = root_hash_update.signatures in
 
@@ -109,10 +114,10 @@ let root_hash_main
     let () = root_hash_check_signatures storage signatures block_hash in
 
     {
-      storage with
       current_block_hash = block_hash;
       current_block_height = block_height;
       current_state_hash = state_hash;
+      current_handles_hash = handles_hash;
       current_validators = validators;
     }
 

--- a/tezos_interop/tezos_interop.re
+++ b/tezos_interop/tezos_interop.re
@@ -390,15 +390,21 @@ module Consensus = {
     |> BLAKE2B.hash;
   let hash = hash => bytes(BLAKE2B.to_raw_string(hash) |> Bytes.of_string);
   let hash_block =
-      (~block_height, ~block_payload_hash, ~state_root_hash, ~validators_hash) =>
+      (~block_height, ~block_payload_hash, ~state_root_hash, ~validators_hash) => {
+    // TODO: this should come from the block in the future
+    let handles_hash = BLAKE2B.hash("");
     to_bytes(
       pair(
-        pair(int(Z.of_int64(block_height)), hash(block_payload_hash)),
-        pair(hash(state_root_hash), hash(validators_hash)),
+        pair(
+          pair(int(Z.of_int64(block_height)), hash(block_payload_hash)),
+          pair(hash(handles_hash), hash(state_root_hash)),
+        ),
+        hash(validators_hash),
       ),
     )
     |> Bytes.to_string
     |> BLAKE2B.hash;
+  };
 };
 
 module Discovery = {


### PR DESCRIPTION
## Depends

- [x] #83 

## Problem

To do withdraws from sidechain to Tezos we need to somehow provide proofs that the ticket was burned on the sidechain.

## Solution

The goal here is to add a hash on every root_hash update for `handles_hash` which is the root hash 
 of a patricia tree from an `id -> data`, this will allow a user to construct a proof when burning tickets.

Note that this is currently not implemented as the sidechain is committing always the same handles_hash and the goal of this PR is only to introduce it in the contract.

## Related

- #34 