### PR TITLE
add withdraw consensus contract

### DIFF
--- a/tezos_interop/consensus.mligo
+++ b/tezos_interop/consensus.mligo
@@ -122,13 +122,25 @@ let root_hash_main
     }
 
 (* vault contract *)
-type vault_storage = (address * bytes, bytes ticket) big_map
+type vault_ticket = bytes ticket
+type vault = (address * bytes, vault_ticket) big_map
+type vault_handle_id = nat
+type vault_used_handle_set = (vault_handle_id, unit) big_map
+type vault_known_handles_hash_set = (blake2b, unit) big_map
+type vault_storage = {
+  known_handles_hash: vault_known_handles_hash_set;
+  used_handles: vault_used_handle_set;
+  vault: vault;
+}
+
+(* deposit entrypoint *)
 type vault_deposit = {
-  ticket: bytes ticket;
+  ticket: vault_ticket;
   (* WARNING: deposit address should be a valid sidechain address *)
   address: address
 }
-let vault_deposit (deposit: vault_deposit) (vault: vault_storage) =
+let vault_deposit (deposit: vault_deposit) (storage: vault_storage) =
+  let { known_handles_hash; used_handles; vault } = storage in
   let (content, ticket) =  Tezos.read_ticket deposit.ticket in
   let (ticketer, (data, _)) = content in
   let (ticket, vault) =
@@ -142,8 +154,130 @@ let vault_deposit (deposit: vault_deposit) (vault: vault_storage) =
     | (Some old_ticket, vault) ->
       (match Tezos.join_tickets (old_ticket, ticket) with
       | Some ticket -> (ticket, vault)
-      | None -> ((failwith "unreachable"): (bytes ticket * vault_storage))) in
-  Big_map.add (ticketer, data) ticket vault
+      | None -> ((failwith "unreachable"): (bytes ticket * vault))) in
+  let vault = Big_map.add (ticketer, data) ticket vault in
+  {
+    known_handles_hash = known_handles_hash;
+    used_handles = used_handles;
+    vault = vault;
+  }
+
+(* withdraw entrypoint *)
+(*
+  flow:
+  validate handle hash
+  validate if handle.id is used
+  validate if the caller is the owner
+  validate if the proof match the data provided
+
+  mark handle.id as used
+  split ticket in fragment and remaining
+  store remaining
+  send fragment to callback
+*)
+
+(* TODO: this could be variable in size *)
+type vault_handle_structure = {
+  (* having the id is really important to change the hash,
+    otherwise people would be able to craft handles using old proofs *)
+  id: vault_handle_id;
+  owner: address;
+  amount: nat;
+  ticketer: address;
+  (* TODO: probably data_hash *)
+  data: bytes;
+}
+type vault_handle_proof = (blake2b * blake2b) list
+type vault_withdraw = {
+  handles_hash: blake2b;
+  handle: vault_handle_structure;
+  proof: vault_handle_proof;
+  callback: vault_ticket contract;
+}
+
+let vault_check_handle_proof
+  (proof: vault_handle_proof)
+  (root: blake2b)
+  (handle: vault_handle_structure) =
+    let bit_is_set (bit: int) =
+      Bitwise.and (Bitwise.shift_left 1n (abs bit)) handle.id <> 0n in
+    let rec verify
+      (bit, proof, parent: int * vault_handle_proof * blake2b): unit =
+        match proof with
+        | [] -> 
+          let calculated_hash = Crypto.blake2b (Bytes.pack handle) in
+          assert_msg ("invalid handle data", parent = calculated_hash)
+        | (left, right) :: tl ->
+          let () = 
+            let calculated_hash = Crypto.blake2b (Bytes.concat left right) in
+            assert_msg ("invalid proof hash", parent = calculated_hash) in
+          verify (bit - 1, tl, (if bit_is_set bit then right else left)) in
+    (* each bit in the handle_id indicates if we should go left or right in
+       the proof, but the first bit to check is the MSB, so we use the length
+       of the proof to know what is the MSB *)
+    let most_significant_bit = int (List.length proof) - 1 in
+    verify (most_significant_bit, proof, root)
+
+let vault_withdraw (withdraw: vault_withdraw) (storage: vault_storage) =
+  let handles_hash = withdraw.handles_hash in
+  let handle = withdraw.handle in
+  let proof = withdraw.proof in
+
+  let { known_handles_hash; used_handles; vault } = storage in
+
+  let () = assert_msg (
+    "unknown handles hash",
+    Big_map.mem handles_hash known_handles_hash
+  ) in
+  let () = assert_msg (
+    "already used handle",
+    not Big_map.mem handle.id used_handles
+  ) in
+  let () = assert_msg (
+    "only the owner can withdraw a handle",
+    handle.owner = Tezos.sender
+  ) in
+  let () = vault_check_handle_proof proof handles_hash handle in
+
+  (* start transfer *)
+  let used_handles = Big_map.add handle.id () used_handles in
+
+  let (fragment, vault) =
+    let (old_ticket, vault) =
+      match 
+        Big_map.get_and_update
+          (handle.ticketer, handle.data)
+          (None: bytes ticket option)
+          vault
+      with
+      | (Some old_ticket, vault) -> (old_ticket, vault)
+      | (None, _) -> (failwith "unreachable" : bytes ticket * vault) in
+    let ((_, (_, total)), old_ticket) = Tezos.read_ticket old_ticket in
+    let (fragment, remaining) =
+      match
+        Tezos.split_ticket
+          old_ticket
+          (handle.amount, abs (total - handle.amount))
+      with
+      | Some (fragment, remaining) -> (fragment, remaining)
+      | None -> (failwith "unreachable" : bytes ticket * bytes ticket) in
+    (fragment, Big_map.add (handle.ticketer, handle.data) remaining vault) in
+  let transaction = Tezos.transaction fragment 0tz withdraw.callback in
+  ([transaction], {
+    known_handles_hash = known_handles_hash;
+    used_handles = used_handles;
+    vault = vault;
+  })
+
+(* bridge between root_hash and vault *)
+let vault_add_handles_hash (handles_hash: blake2b) (storage: vault_storage) =
+  let { known_handles_hash; used_handles; vault } = storage in
+  let known_handles_hash = Big_map.add handles_hash () known_handles_hash in
+  {
+    known_handles_hash = known_handles_hash;
+    used_handles = used_handles;
+    vault = vault;
+  }
 
 (* main contract *)
 type storage = {
@@ -153,13 +287,21 @@ type storage = {
 type action =
   | Update_root_hash of root_hash_action
   | Deposit of vault_deposit
+  | Withdraw of vault_withdraw
 
 let main (action, storage : action * storage) =
   let { root_hash; vault } = storage in
   match action with
   | Update_root_hash root_hash_update ->
     let root_hash = root_hash_main root_hash_update root_hash in
+    let vault =
+      vault_add_handles_hash
+        root_hash.current_handles_hash
+        vault in
     (([] : operation list), { root_hash = root_hash; vault = vault })
   | Deposit deposit ->
       let vault = vault_deposit deposit vault in
       (([] : operation list), { root_hash = root_hash; vault = vault; })
+  | Withdraw withdraw ->
+    let (operations, vault) = vault_withdraw withdraw vault in
+    (operations, { root_hash = root_hash; vault = vault; })


### PR DESCRIPTION
## Depends

- [x] #85

## Problem

To achieve #34 we need a way to move money outside of the sidechain and have a proof to it so that Tezos can verify it.

## Solution

As #85 we have the handles_hash here we add them for a set of handle_hash and when the user tries to withdraw it we verify the proof by assuming the hash represents a patricia tree where the key is always an incremental int.

After doing a withdraw the handle is added to a set of handles_id so that it cannot be used again.

## Related

- #34 