### PR TITLE
add hash_withdraw_handle on tezos interop

### DIFF
--- a/tests/test_tezos_interop.re
+++ b/tests/test_tezos_interop.re
@@ -339,6 +339,7 @@ describe("consensus", ({test, _}) => {
 
   let hash_exn = s => BLAKE2B.of_string(s) |> Option.get;
   let key_exn = s => Key.of_string(s) |> Option.get;
+  let address_exn = s => Address.of_string(s) |> Option.get;
 
   test("hash_validators", ({expect, _}) => {
     let hash =
@@ -373,6 +374,20 @@ describe("consensus", ({test, _}) => {
     let hash = BLAKE2B.to_string(hash);
     expect.string(hash).toEqual(
       "23cdb9e9ffef6dd17553b622af0c043f544daa18430dff295d04a9d46b3e5267",
+    );
+  });
+  test("hash_withdraw_handle", ({expect, _}) => {
+    let hash =
+      hash_withdraw_handle(
+        ~id=Z.of_int(0),
+        ~owner=address_exn("tz1YywYq77UAMbVgoYndnZLkRawjUhX3nVh4"),
+        ~amount=Z.of_int(10),
+        ~ticketer=address_exn("KT1AS9rCk1wpybsvZ5Tnd4yRxDvtN39uxMoq"),
+        ~data=Bytes.of_string(""),
+      );
+    let hash = BLAKE2B.to_string(hash);
+    expect.string(hash).toEqual(
+      "63dfd90ec7be98a9c23bf374692de4d36f41fe03c4c768fc0c650641d3ed4f86",
     );
   });
 });

--- a/tezos_interop/tezos_interop.rei
+++ b/tezos_interop/tezos_interop.rei
@@ -95,6 +95,15 @@ module Consensus: {
       ~validators_hash: BLAKE2B.t
     ) =>
     BLAKE2B.t;
+  let hash_withdraw_handle:
+    (
+      ~id: Z.t,
+      ~owner: Address.t,
+      ~amount: Z.t,
+      ~ticketer: Address.t,
+      ~data: bytes
+    ) =>
+    BLAKE2B.t;
 };
 
 module Discovery: {let sign: (Secret.t, ~nonce: int64, Uri.t) => Signature.t;};


### PR DESCRIPTION
## Depends

To keep the PR dependency graph simple, this one depends on

- [x] #74 

## Problem

#88 adds on the Tezos contract a `handle_structure` which when combined with the `handles_hash` allow us to communicate proofs about the sidechain to Tezos, but currently there is no way to hash `handle_structure` on the sidechain.

## Solution

This implements `hash_withdraw_handle` which creates a hash compatible with #88 `handle_structure`.

## Related

- #34
- #88 
