### PR TITLE
add yojson on tezos interop address

### DIFF
--- a/bin/files.re
+++ b/bin/files.re
@@ -49,15 +49,6 @@ module Validators = {
 };
 
 module Interop_context = {
-  module Address = {
-    include Tezos_interop.Address;
-    let of_yojson =
-      fun
-      | `String(string) =>
-        of_string(string) |> Option.to_result(~none="invalid address")
-      | _ => Error("expected a string");
-    let to_yojson = t => `String(to_string(t));
-  };
   module Secret = {
     include Tezos_interop.Secret;
     let of_yojson =
@@ -73,7 +64,7 @@ module Interop_context = {
     Tezos_interop.Context.t = {
       rpc_node: Uri.t,
       secret: Secret.t,
-      consensus_contract: Address.t,
+      consensus_contract: Tezos_interop.Address.t,
       required_confirmations: int,
     };
 

--- a/protocol/ledger.re
+++ b/protocol/ledger.re
@@ -18,23 +18,11 @@ module Wallet_and_ticket_map = {
   let add = (address, ticket) => Map.add({address, ticket});
 };
 module Handle = {
-  module Address = {
-    include Tezos_interop.Address;
-    // TODO: this duplicated from Ticket.re and should be cleaned
-    let with_yojson_string = (name, of_string, to_string) =>
-      Helpers.with_yojson_string(
-        string =>
-          of_string(string) |> Option.to_result(~none="invalid " ++ name),
-        to_string,
-      );
-    let (of_yojson, to_yojson) =
-      with_yojson_string("address", of_string, to_string);
-  };
   [@deriving yojson]
   type t = {
     hash: BLAKE2B.t,
     id: int,
-    owner: Address.t,
+    owner: Tezos_interop.Address.t,
     amount: Amount.t,
     ticket: Ticket.t,
   };

--- a/protocol/ticket.re
+++ b/protocol/ticket.re
@@ -1,18 +1,5 @@
 open Tezos_interop;
 
-// TODO: I feel uneasy about this module
-module Address = {
-  include Address;
-  let with_yojson_string = (name, of_string, to_string) =>
-    Helpers.with_yojson_string(
-      string =>
-        of_string(string) |> Option.to_result(~none="invalid " ++ name),
-      to_string,
-    );
-  let (of_yojson, to_yojson) =
-    with_yojson_string("address", of_string, to_string);
-};
-
 [@deriving yojson]
 type t =
   Ticket.t = {

--- a/tezos_interop/tezos_interop.re
+++ b/tezos_interop/tezos_interop.re
@@ -266,6 +266,15 @@ module Address = {
     };
     try_decode_list([implicit, originated]);
   };
+
+  let with_yojson_string = (name, of_string, to_string) =>
+    Helpers.with_yojson_string(
+      string =>
+        of_string(string) |> Option.to_result(~none="invalid " ++ name),
+      to_string,
+    );
+  let (of_yojson, to_yojson) =
+    with_yojson_string("address", of_string, to_string);
 };
 
 module Signature = {

--- a/tezos_interop/tezos_interop.rei
+++ b/tezos_interop/tezos_interop.rei
@@ -52,6 +52,9 @@ module Address: {
 
   let to_string: t => string;
   let of_string: string => option(t);
+
+  let to_yojson: t => Yojson.Safe.t;
+  let of_yojson: Yojson.Safe.t => result(t, string);
 };
 
 module Ticket: {


### PR DESCRIPTION
## Depends

This dependency is just to keep the PR graph simple.

- [x] #90

## Problem

In a couple different places we're duplicating code because currently Tezos_interop only exposes primitives, while this is desirable the cost of it right know is too high.

## Solution

This is the first step to solve that by adding `to_yojson` and `of_yojson` on `Tezos_interop.Address`