### PR TITLE
add deposit operation

### DIFF
--- a/protocol/operation.re
+++ b/protocol/operation.re
@@ -1,12 +1,17 @@
 open Helpers;
 
 module Main_chain = {
-  [@deriving (ord, yojson)]
+  [@deriving yojson]
   type kind =
     // TODO: can a validator uses the same key in different nodes?
     // If so the ordering in the list must never use the same key two times in sequence
     | Add_validator(Validators.validator)
-    | Remove_validator(Validators.validator);
+    | Remove_validator(Validators.validator)
+    | Deposit({
+        destination: Wallet.t,
+        amount: Amount.t,
+        ticket: Ticket.t,
+      });
   [@deriving yojson]
   type t = {
     tezos_hash: BLAKE2B.t,
@@ -21,10 +26,10 @@ module Main_chain = {
 
 module Side_chain = {
   // TODO: I don't like this structure model
-  [@deriving (ord, yojson)]
+  [@deriving yojson]
   type kind =
     | Transaction({destination: Wallet.t});
-  [@deriving (ord, yojson)]
+  [@deriving yojson]
   type t = {
     hash: BLAKE2B.t,
     signature: Signature.t,
@@ -35,6 +40,7 @@ module Side_chain = {
     ticket: Ticket.t,
     kind,
   };
+  let compare = (a, b) => BLAKE2B.compare(a.hash, b.hash);
 
   let (hash, verify) = {
     /* TODO: this is bad name, it exists like this to prevent

--- a/protocol/operation.rei
+++ b/protocol/operation.rei
@@ -1,11 +1,16 @@
 open Helpers;
 module Main_chain: {
-  [@deriving (ord, yojson)]
+  [@deriving yojson]
   type kind =
     // TODO: can a validator uses the same key in different nodes?
     // If so the ordering in the list must never use the same key two times in sequence
     | Add_validator(Validators.validator)
-    | Remove_validator(Validators.validator);
+    | Remove_validator(Validators.validator)
+    | Deposit({
+        destination: Wallet.t,
+        amount: Amount.t,
+        ticket: Ticket.t,
+      });
 
   [@deriving (ord, yojson)]
   type t =
@@ -19,7 +24,7 @@ module Main_chain: {
 
 module Side_chain: {
   // TODO: I don't like this structure model
-  [@deriving (ord, yojson)]
+  [@deriving yojson]
   type kind =
     | Transaction({destination: Wallet.t});
   [@deriving (ord, yojson)]

--- a/protocol/protocol.re
+++ b/protocol/protocol.re
@@ -22,6 +22,9 @@ let apply_main_chain = (state, op) => {
     | Remove_validator(validator) =>
       let validators = Validators.remove(validator, state.validators);
       {...state, validators};
+    | Deposit({destination, amount, ticket}) =>
+      let ledger = Ledger.deposit(destination, amount, ticket, state.ledger);
+      {...state, ledger};
     }
   );
 };


### PR DESCRIPTION
## Depends

- [x] #91 

## Problem

As part of the progress of #34 we removed the deposit operation so that it could be redesigned without major problems, but to finish it we need to add deposit back.

## Solution

This PR adds a deposit operation which should(in the future) be detected when someone calls the deposit entrypoint on Tezos as per #83 

## Related

- #34 
- #83 