### PR TITLE
add withdraw operation

### DIFF
--- a/protocol/operation.re
+++ b/protocol/operation.re
@@ -28,7 +28,8 @@ module Side_chain = {
   // TODO: I don't like this structure model
   [@deriving yojson]
   type kind =
-    | Transaction({destination: Wallet.t});
+    | Transaction({destination: Wallet.t})
+    | Withdraw({owner: Tezos_interop.Address.t});
   [@deriving yojson]
   type t = {
     hash: BLAKE2B.t,

--- a/protocol/operation.rei
+++ b/protocol/operation.rei
@@ -26,7 +26,8 @@ module Side_chain: {
   // TODO: I don't like this structure model
   [@deriving yojson]
   type kind =
-    | Transaction({destination: Wallet.t});
+    | Transaction({destination: Wallet.t})
+    | Withdraw({owner: Tezos_interop.Address.t});
   [@deriving (ord, yojson)]
   type t =
     pri {

--- a/protocol/protocol.re
+++ b/protocol/protocol.re
@@ -61,6 +61,17 @@ let apply_side_chain = (state: t, operation) => {
     switch (operation.kind) {
     | Transaction({destination}) =>
       Ledger.transfer(~source, ~destination, amount, ticket, state.ledger)
+    | Withdraw({owner}) =>
+      let.ok (ledger, _handle) =
+        Ledger.withdraw(
+          ~source,
+          ~destination=owner,
+          amount,
+          ticket,
+          state.ledger,
+        );
+      // TODO: publish the handle somewhere
+      Ok(ledger);
     };
   let ledger =
     switch (ledger) {


### PR DESCRIPTION
## Depends

To keep the dependency graph simple

- [x] #92 

## Problem

As part of the progress of #34 we removed the withdraw operation so that it could be redesigned without major problems, but to finish it we need to add withdraw back.

## Solution

This PR adds a withdraw operation which permits the user to burn the money on the sidechain and get a proof of it(in a future PR) to use it on the withdraw entrypoint on Tezos as per #88

## Related

- #34 
- #88