### PR TITLE
add interop context to node state

### DIFF
--- a/bin/http_server.re
+++ b/bin/http_server.re
@@ -171,6 +171,8 @@ let node = {
   let.await identity = Files.Identity.read(~file=folder ++ "/identity.json");
   let.await validators =
     Files.Validators.read(~file=folder ++ "/validators.json");
+  let.await interop_context =
+    Files.Interop_context.read(~file=folder ++ "/tezos.json");
   let initial_validators_uri =
     List.fold_left(
       (validators_uri, (address, uri)) =>
@@ -179,7 +181,12 @@ let node = {
       validators,
     );
   let node =
-    State.make(~identity, ~data_folder=folder, ~initial_validators_uri);
+    State.make(
+      ~identity,
+      ~interop_context,
+      ~data_folder=folder,
+      ~initial_validators_uri,
+    );
   let node = {
     ...node,
     protocol: {

--- a/node/state.re
+++ b/node/state.re
@@ -13,6 +13,7 @@ module Uri_map = Map.Make(Uri);
 
 type t = {
   identity,
+  interop_context: Tezos_interop.Context.t,
   data_folder: string,
   pending_side_ops: list(Operation.Side_chain.t),
   pending_main_ops: list(Operation.Main_chain.t),
@@ -28,7 +29,8 @@ type t = {
   validators_uri: Address_map.t(Uri.t),
 };
 
-let make = (~identity, ~data_folder, ~initial_validators_uri) => {
+let make =
+    (~identity, ~interop_context, ~data_folder, ~initial_validators_uri) => {
   let initial_block = Block.genesis;
   let initial_protocol = Protocol.make(~initial_block);
   let initial_signatures =
@@ -43,6 +45,7 @@ let make = (~identity, ~data_folder, ~initial_validators_uri) => {
   };
   {
     identity,
+    interop_context,
     data_folder,
     pending_side_ops: [],
     pending_main_ops: [],

--- a/node/state.rei
+++ b/node/state.rei
@@ -12,6 +12,7 @@ module Address_map: Map.S with type key = Address.t;
 module Uri_map: Map.S with type key = Uri.t;
 type t = {
   identity,
+  interop_context: Tezos_interop.Context.t,
   data_folder: string,
   pending_side_ops: list(Operation.Side_chain.t),
   pending_main_ops: list(Operation.Main_chain.t),
@@ -26,6 +27,7 @@ type t = {
 let make:
   (
     ~identity: identity,
+    ~interop_context: Tezos_interop.Context.t,
     ~data_folder: string,
     ~initial_validators_uri: Address_map.t(Uri.t)
   ) =>


### PR DESCRIPTION
## Problem

Currently the node cannot access the Tezos context which makes so that future PRs that require communication to Tezos currently don't work.

## Solution

Add the context to the node state so that it can communicate to Tezos.

## Related

- #61 