### PR TITLE
add commit_state_hash to Tezos_interop

### DIFF
--- a/tezos_interop/dune
+++ b/tezos_interop/dune
@@ -1,3 +1,5 @@
 (library
  (name tezos_interop)
- (libraries helpers mirage-crypto-ec tezos-micheline))
+ (libraries helpers lwt.unix mirage-crypto-ec tezos-micheline)
+ (preprocess
+  (pps ppx_deriving_yojson)))

--- a/tezos_interop/tezos_interop.re
+++ b/tezos_interop/tezos_interop.re
@@ -464,13 +464,14 @@ module Consensus = {
 
   let hash_packed_data = data =>
     data |> to_bytes |> Bytes.to_string |> BLAKE2B.hash;
+  // TODO: this should come from the block in the future
+  let handles_hash = BLAKE2B.hash("");
+
   let hash_validators = validators =>
     list(List.map(key, validators)) |> hash_packed_data;
   let hash = hash => bytes(BLAKE2B.to_raw_string(hash) |> Bytes.of_string);
   let hash_block =
-      (~block_height, ~block_payload_hash, ~state_root_hash, ~validators_hash) => {
-    // TODO: this should come from the block in the future
-    let handles_hash = BLAKE2B.hash("");
+      (~block_height, ~block_payload_hash, ~state_root_hash, ~validators_hash) =>
     pair(
       pair(
         pair(int(Z.of_int64(block_height)), hash(block_payload_hash)),
@@ -479,7 +480,6 @@ module Consensus = {
       hash(validators_hash),
     )
     |> hash_packed_data;
-  };
   let hash_withdraw_handle = (~id, ~owner, ~amount, ~ticketer, ~data) =>
     pair(
       pair(
@@ -489,6 +489,59 @@ module Consensus = {
       address(ticketer),
     )
     |> hash_packed_data;
+
+  // TODO: how to test this?
+  let commit_state_hash =
+      (
+        ~context,
+        ~block_hash,
+        ~block_height,
+        ~block_payload_hash,
+        ~state_hash,
+        ~validators,
+        ~signatures,
+      ) => {
+    module Payload = {
+      [@deriving to_yojson]
+      type t = {
+        block_hash: BLAKE2B.t,
+        block_height: int64,
+        block_payload_hash: BLAKE2B.t,
+        signatures: list(option(string)),
+        handles_hash: BLAKE2B.t,
+        state_hash: BLAKE2B.t,
+        validators: list(string),
+      };
+    };
+    open Payload;
+    let signatures =
+      // TODO: we should sort the map using the keys
+      List.map(
+        ((_key, signature)) =>
+          Option.map(signature => Signature.to_string(signature), signature),
+        signatures,
+      );
+    let validators = List.map(Key.to_string, validators);
+    let payload = {
+      block_hash,
+      block_height,
+      block_payload_hash,
+      signatures,
+      handles_hash,
+      state_hash,
+      validators,
+    };
+    // TODO: what should this code do with the output? Retry?
+    //      return back that it was a failure?
+    let.await _ =
+      Run_contract.run(
+        ~context,
+        ~destination=context.Context.consensus_contract,
+        ~entrypoint="default",
+        ~payload=Payload.to_yojson(payload),
+      );
+    await();
+  };
 };
 
 module Discovery = {

--- a/tezos_interop/tezos_interop.rei
+++ b/tezos_interop/tezos_interop.rei
@@ -107,6 +107,19 @@ module Consensus: {
       ~data: bytes
     ) =>
     BLAKE2B.t;
+
+  /** ~signatures should be in the same order as the old validators */
+  let commit_state_hash:
+    (
+      ~context: Context.t,
+      ~block_hash: BLAKE2B.t,
+      ~block_height: int64,
+      ~block_payload_hash: BLAKE2B.t,
+      ~state_hash: BLAKE2B.t,
+      ~validators: list(Key.t),
+      ~signatures: list((Key.t, option(Signature.t)))
+    ) =>
+    Lwt.t(unit);
 };
 
 module Discovery: {let sign: (Secret.t, ~nonce: int64, Uri.t) => Signature.t;};


### PR DESCRIPTION
## Problem

To achieve #61 we need to be able to commit the state hash from inside of the node.

## Solution

This is a movement in this direction, it integrates on the CLI provided by #98 and exposes `commit_state_hash` which allows the node to call and submit the operation to Tezos.

## Related

- #61 