### PR TITLE
ci: run dune build @check

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -27,6 +27,9 @@ jobs:
 
       - name: Run Code formatter
         run: esy b dune build @fmt
+      
+      - name: Run Check
+        run: esy b dune build @check
 
       - name: Run tests
         run: esy test

--- a/bin/sidecli.re
+++ b/bin/sidecli.re
@@ -117,22 +117,6 @@ let ticket = {
     Format.fprintf(fmt, "%S", Tezos_interop.Ticket.to_string(ticket));
   Arg.(conv(~docv="A ticket", (parser, printer)));
 };
-// TODO: Wallet.t
-let wallet = {
-  let parser = file => {
-    let non_dir_file = Arg.(conv_parser(non_dir_file));
-    switch (
-      non_dir_file(file),
-      non_dir_file(make_filename_from_address(file)),
-    ) {
-    | (Ok(file), _)
-    | (_, Ok(file)) => Ok(file)
-    | _ => Error(`Msg("Expected path to wallet"))
-    };
-  };
-  let printer = Arg.(conv_printer(non_dir_file));
-  Arg.(conv((parser, printer)));
-};
 
 // Commands
 // ========


### PR DESCRIPTION
## Problem

On a previous PR a duplicated block was introduced and this was not detected by the CI as we're always running build in production mode.

## Solution

On this PR we also call `dune build @check` on the CI so that all the possible warnings are detected during future PRs and also fix the example.