### PR TITLE
add handles hash to block

### DIFF
--- a/bin/http_server.re
+++ b/bin/http_server.re
@@ -164,6 +164,7 @@ let handle_data_to_smart_contract =
         block_height: block.block_height,
         block_payload_hash: block.payload_hash,
         state_hash: block.state_root_hash,
+        handles_hash: block.handles_hash,
         validators,
         signatures,
       });

--- a/node/networking.re
+++ b/node/networking.re
@@ -166,6 +166,7 @@ module Data_to_smart_contract = {
     block_height: int64,
     block_payload_hash: BLAKE2B.t,
     state_hash: BLAKE2B.t,
+    handles_hash: BLAKE2B.t,
     validators: list(string),
     signatures: list(option(string)),
   };

--- a/protocol/block.rei
+++ b/protocol/block.rei
@@ -7,6 +7,7 @@ type t =
     hash: BLAKE2B.t,
     payload_hash: BLAKE2B.t,
     state_root_hash: BLAKE2B.t,
+    handles_hash: BLAKE2B.t,
     validators_hash: BLAKE2B.t,
     previous_hash: BLAKE2B.t,
     author: Address.t,

--- a/tests/test_tezos_interop.re
+++ b/tests/test_tezos_interop.re
@@ -357,14 +357,18 @@ describe("consensus", ({test, _}) => {
   test("hash_block", ({expect, _}) => {
     let hash =
       hash_block(
-        ~block_height=179842L,
+        ~block_height=121L,
         ~block_payload_hash=
           hash_exn(
-            "e2b8630f4dbda366f4c5e781e9c421780580566c2b7076f9cff142e58cbad972",
+            "2d92960a592c56de3046e200969c230a2eda71fc4b775e0cc09a189e5ddc5dbd",
           ),
         ~state_root_hash=
           hash_exn(
-            "7b54374657fc7b0e681ee618d4a13129b2d0c47e8ffb0460f02ac8d324c0b134",
+            "bdd051ddb07925a0d88dc27583e38ae560aa1b4429cc93b9ec35dacdbd74ffb2",
+          ),
+        ~handles_hash=
+          hash_exn(
+            "0e5751c026e543b2e8ab2eb06099daa1d1e5df47778f7787faab45cdf12fe3a8",
           ),
         ~validators_hash=
           hash_exn(
@@ -373,7 +377,7 @@ describe("consensus", ({test, _}) => {
       );
     let hash = BLAKE2B.to_string(hash);
     expect.string(hash).toEqual(
-      "23cdb9e9ffef6dd17553b622af0c043f544daa18430dff295d04a9d46b3e5267",
+      "7cb600c19817b899d4c28c521dd9ebf95f688e1444afe7d0e7740bebe848b030",
     );
   });
   test("hash_withdraw_handle", ({expect, _}) => {

--- a/tezos_interop/tezos_interop.re
+++ b/tezos_interop/tezos_interop.re
@@ -464,14 +464,18 @@ module Consensus = {
 
   let hash_packed_data = data =>
     data |> to_bytes |> Bytes.to_string |> BLAKE2B.hash;
-  // TODO: this should come from the block in the future
-  let handles_hash = BLAKE2B.hash("");
 
   let hash_validators = validators =>
     list(List.map(key, validators)) |> hash_packed_data;
   let hash = hash => bytes(BLAKE2B.to_raw_string(hash) |> Bytes.of_string);
   let hash_block =
-      (~block_height, ~block_payload_hash, ~state_root_hash, ~validators_hash) =>
+      (
+        ~block_height,
+        ~block_payload_hash,
+        ~state_root_hash,
+        ~handles_hash,
+        ~validators_hash,
+      ) =>
     pair(
       pair(
         pair(int(Z.of_int64(block_height)), hash(block_payload_hash)),
@@ -498,6 +502,7 @@ module Consensus = {
         ~block_height,
         ~block_payload_hash,
         ~state_hash,
+        ~handles_hash,
         ~validators,
         ~signatures,
       ) => {

--- a/tezos_interop/tezos_interop.rei
+++ b/tezos_interop/tezos_interop.rei
@@ -95,6 +95,7 @@ module Consensus: {
       ~block_height: int64,
       ~block_payload_hash: BLAKE2B.t,
       ~state_root_hash: BLAKE2B.t,
+      ~handles_hash: BLAKE2B.t,
       ~validators_hash: BLAKE2B.t
     ) =>
     BLAKE2B.t;
@@ -116,6 +117,7 @@ module Consensus: {
       ~block_height: int64,
       ~block_payload_hash: BLAKE2B.t,
       ~state_hash: BLAKE2B.t,
+      ~handles_hash: BLAKE2B.t,
       ~validators: list(Key.t),
       ~signatures: list((Key.t, option(Signature.t)))
     ) =>


### PR DESCRIPTION
## Problem

Currently the `handles_hash` is hardcoded not carrying the ledger proofs. So not being useful for withdraws.

## Solution

Here we route the data from the ledger to a block, where it will be signed and eventually commited to the main chain where it can be then inspected and used for withdraws.

## Related

- #34 
- Same as #103