### PR TITLE
try to commit state hash every new snapshot

### DIFF
--- a/tezos_interop/tezos_interop.re
+++ b/tezos_interop/tezos_interop.re
@@ -301,6 +301,10 @@ module Signature = {
     };
     try_decode_list([ed25519]);
   };
+  // TODO: this is a leaky abstraction
+  let of_raw_string =
+    fun
+    | `Ed25519(data) => Ed25519(data);
 };
 
 module Ticket = {

--- a/tezos_interop/tezos_interop.rei
+++ b/tezos_interop/tezos_interop.rei
@@ -36,6 +36,9 @@ module Signature: {
 
   let to_string: t => string;
   let of_string: string => option(t);
+
+  // TODO: this is a leaky abstraction
+  let of_raw_string: [ | `Ed25519(string)] => t;
 };
 
 module Contract_hash: {


### PR DESCRIPTION
## Problem

We need to commit the state hash to Tezos periodically so that it can be used for things like withdraws.

## Solution

Here we just try to commit the state hash every new state hash, but with a delay of 120 seconds if you're not the author of the block, that way we avoid a bunch of validators trying to commit at the same time without a good reason.

This is not a good decision but it's a temporary fix in the direction of #61 

## Related

- #34 
- #61 