### PR TITLE
Inline JS scripts inside the node binary

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -19,7 +19,7 @@ jobs:
           node-version: 14
 
       - name: Install esy
-        run: npm install -g esy
+        run: npm install -g @esy-nightly/esy
 
       - uses: esy/github-action@master
         with:

--- a/.gitignore
+++ b/.gitignore
@@ -2,3 +2,4 @@ _esy
 node_modules
 data
 *.install
+*.bundle.js

--- a/esy.lock/index.json
+++ b/esy.lock/index.json
@@ -1,5 +1,5 @@
 {
-  "checksum": "202de74e166ed04e8badbb51e70100a7",
+  "checksum": "41a3676ed7f27e8413521ecd8f207b69",
   "root": "sidechain@link-dev:./package.json",
   "node": {
     "yocto-queue@0.1.0@d41d8cd9": {
@@ -479,6 +479,7 @@
         "@opam/tezos-micheline@opam:8.3@f8cfe30f",
         "@opam/ppx_deriving_yojson@opam:3.6.1@faf11a7c",
         "@opam/ppx_deriving@opam:5.2.1@089e5dd3",
+        "@opam/ppx_blob@opam:0.7.2@f89ed130",
         "@opam/piaf@github:EduardoRFS/piaf:piaf.opam#8e4eeb916aef8e95f04d98eef57c43f07008b631@d41d8cd9",
         "@opam/opium@github:EduardoRFS/opium:opium.opam#9fdbfbd0eedf238e1be0663ab95977be27d9a6e1@d41d8cd9",
         "@opam/mrmime@opam:0.3.2@2b4fe265",
@@ -4247,6 +4248,33 @@
       "devDependencies": [
         "ocaml@github:esy-ocaml/ocaml#7af70dea28d218eb53bce7966e24dfe6762862ae@d41d8cd9",
         "@opam/dune@opam:2.9.0@489e77a9"
+      ]
+    },
+    "@opam/ppx_blob@opam:0.7.2@f89ed130": {
+      "id": "@opam/ppx_blob@opam:0.7.2@f89ed130",
+      "name": "@opam/ppx_blob",
+      "version": "opam:0.7.2",
+      "source": {
+        "type": "install",
+        "source": [
+          "archive:https://opam.ocaml.org/cache/sha256/bc/bcb9dcab18a3b40b5d6d9656575001c6379abf29461aa87d9263d25b59f80a02#sha256:bcb9dcab18a3b40b5d6d9656575001c6379abf29461aa87d9263d25b59f80a02",
+          "archive:https://github.com/johnwhitington/ppx_blob/releases/download/0.7.2/ppx_blob-0.7.2.tbz#sha256:bcb9dcab18a3b40b5d6d9656575001c6379abf29461aa87d9263d25b59f80a02"
+        ],
+        "opam": {
+          "name": "ppx_blob",
+          "version": "0.7.2",
+          "path": "esy.lock/opam/ppx_blob.0.7.2"
+        }
+      },
+      "overrides": [],
+      "dependencies": [
+        "ocaml@github:esy-ocaml/ocaml#7af70dea28d218eb53bce7966e24dfe6762862ae@d41d8cd9",
+        "@opam/ppxlib@opam:0.22.2@61009929",
+        "@opam/dune@opam:2.9.0@489e77a9", "@esy-ocaml/substs@0.0.1@d41d8cd9"
+      ],
+      "devDependencies": [
+        "ocaml@github:esy-ocaml/ocaml#7af70dea28d218eb53bce7966e24dfe6762862ae@d41d8cd9",
+        "@opam/ppxlib@opam:0.22.2@61009929", "@opam/dune@opam:2.9.0@489e77a9"
       ]
     },
     "@opam/pp@opam:1.1.2@89ad03b5": {

--- a/esy.lock/index.json
+++ b/esy.lock/index.json
@@ -1,7 +1,21 @@
 {
-  "checksum": "961787d2abfcfb599ccae2acb23baada",
+  "checksum": "202de74e166ed04e8badbb51e70100a7",
   "root": "sidechain@link-dev:./package.json",
   "node": {
+    "yocto-queue@0.1.0@d41d8cd9": {
+      "id": "yocto-queue@0.1.0@d41d8cd9",
+      "name": "yocto-queue",
+      "version": "0.1.0",
+      "source": {
+        "type": "install",
+        "source": [
+          "archive:https://registry.npmjs.org/yocto-queue/-/yocto-queue-0.1.0.tgz#sha1:0294eb3dee05028d31ee1a5fa2c556a6aaf10a1b"
+        ]
+      },
+      "overrides": [],
+      "dependencies": [],
+      "devDependencies": []
+    },
     "yarn-pkg-config@github:esy-ocaml/yarn-pkg-config#db3a0b63883606dd57c54a7158d560d6cba8cd79@d41d8cd9": {
       "id":
         "yarn-pkg-config@github:esy-ocaml/yarn-pkg-config#db3a0b63883606dd57c54a7158d560d6cba8cd79@d41d8cd9",
@@ -32,6 +46,146 @@
       "dependencies": [ "cookiejar@2.1.2@d41d8cd9" ],
       "devDependencies": []
     },
+    "wildcard@2.0.0@d41d8cd9": {
+      "id": "wildcard@2.0.0@d41d8cd9",
+      "name": "wildcard",
+      "version": "2.0.0",
+      "source": {
+        "type": "install",
+        "source": [
+          "archive:https://registry.npmjs.org/wildcard/-/wildcard-2.0.0.tgz#sha1:a77d20e5200c6faaac979e4b3aadc7b3dd7f8fec"
+        ]
+      },
+      "overrides": [],
+      "dependencies": [],
+      "devDependencies": []
+    },
+    "which@2.0.2@d41d8cd9": {
+      "id": "which@2.0.2@d41d8cd9",
+      "name": "which",
+      "version": "2.0.2",
+      "source": {
+        "type": "install",
+        "source": [
+          "archive:https://registry.npmjs.org/which/-/which-2.0.2.tgz#sha1:7c6a8dd0a636a0327e10b59c9286eee93f3f51b1"
+        ]
+      },
+      "overrides": [],
+      "dependencies": [ "isexe@2.0.0@d41d8cd9" ],
+      "devDependencies": []
+    },
+    "webpack-sources@3.1.2@d41d8cd9": {
+      "id": "webpack-sources@3.1.2@d41d8cd9",
+      "name": "webpack-sources",
+      "version": "3.1.2",
+      "source": {
+        "type": "install",
+        "source": [
+          "archive:https://registry.npmjs.org/webpack-sources/-/webpack-sources-3.1.2.tgz#sha1:614c962ac45dfac7f0f482052db8324a6e0dc274"
+        ]
+      },
+      "overrides": [],
+      "dependencies": [],
+      "devDependencies": []
+    },
+    "webpack-merge@5.8.0@d41d8cd9": {
+      "id": "webpack-merge@5.8.0@d41d8cd9",
+      "name": "webpack-merge",
+      "version": "5.8.0",
+      "source": {
+        "type": "install",
+        "source": [
+          "archive:https://registry.npmjs.org/webpack-merge/-/webpack-merge-5.8.0.tgz#sha1:2b39dbf22af87776ad744c390223731d30a68f61"
+        ]
+      },
+      "overrides": [],
+      "dependencies": [
+        "wildcard@2.0.0@d41d8cd9", "clone-deep@4.0.1@d41d8cd9"
+      ],
+      "devDependencies": []
+    },
+    "webpack-cli@4.7.2@d41d8cd9": {
+      "id": "webpack-cli@4.7.2@d41d8cd9",
+      "name": "webpack-cli",
+      "version": "4.7.2",
+      "source": {
+        "type": "install",
+        "source": [
+          "archive:https://registry.npmjs.org/webpack-cli/-/webpack-cli-4.7.2.tgz#sha1:a718db600de6d3906a4357e059ae584a89f4c1a5"
+        ]
+      },
+      "overrides": [],
+      "dependencies": [
+        "webpack-merge@5.8.0@d41d8cd9", "webpack@5.47.1@d41d8cd9",
+        "v8-compile-cache@2.3.0@d41d8cd9", "rechoir@0.7.1@d41d8cd9",
+        "interpret@2.2.0@d41d8cd9", "import-local@3.0.2@d41d8cd9",
+        "fastest-levenshtein@1.0.12@d41d8cd9", "execa@5.1.1@d41d8cd9",
+        "commander@7.2.0@d41d8cd9", "colorette@1.2.2@d41d8cd9",
+        "@webpack-cli/serve@1.5.1@d41d8cd9",
+        "@webpack-cli/info@1.3.0@d41d8cd9",
+        "@webpack-cli/configtest@1.0.4@d41d8cd9",
+        "@discoveryjs/json-ext@0.5.3@d41d8cd9"
+      ],
+      "devDependencies": []
+    },
+    "webpack@5.47.1@d41d8cd9": {
+      "id": "webpack@5.47.1@d41d8cd9",
+      "name": "webpack",
+      "version": "5.47.1",
+      "source": {
+        "type": "install",
+        "source": [
+          "archive:https://registry.npmjs.org/webpack/-/webpack-5.47.1.tgz#sha1:20fb7d76f68912a2249a6dd7ff16faa178049ad2"
+        ]
+      },
+      "overrides": [],
+      "dependencies": [
+        "webpack-sources@3.1.2@d41d8cd9", "watchpack@2.2.0@d41d8cd9",
+        "terser-webpack-plugin@5.1.4@d41d8cd9", "tapable@2.2.0@d41d8cd9",
+        "schema-utils@3.1.1@d41d8cd9", "neo-async@2.6.2@d41d8cd9",
+        "mime-types@2.1.32@d41d8cd9", "loader-runner@4.2.0@d41d8cd9",
+        "json-parse-better-errors@1.0.2@d41d8cd9",
+        "graceful-fs@4.2.6@d41d8cd9", "glob-to-regexp@0.4.1@d41d8cd9",
+        "events@3.3.0@d41d8cd9", "eslint-scope@5.1.1@d41d8cd9",
+        "es-module-lexer@0.7.1@d41d8cd9", "enhanced-resolve@5.8.2@d41d8cd9",
+        "chrome-trace-event@1.0.3@d41d8cd9", "browserslist@4.16.6@d41d8cd9",
+        "acorn@8.4.1@d41d8cd9", "@webassemblyjs/wasm-parser@1.11.1@d41d8cd9",
+        "@webassemblyjs/wasm-edit@1.11.1@d41d8cd9",
+        "@webassemblyjs/ast@1.11.1@d41d8cd9",
+        "@types/estree@0.0.50@d41d8cd9", "@types/eslint-scope@3.7.1@d41d8cd9"
+      ],
+      "devDependencies": []
+    },
+    "watchpack@2.2.0@d41d8cd9": {
+      "id": "watchpack@2.2.0@d41d8cd9",
+      "name": "watchpack",
+      "version": "2.2.0",
+      "source": {
+        "type": "install",
+        "source": [
+          "archive:https://registry.npmjs.org/watchpack/-/watchpack-2.2.0.tgz#sha1:47d78f5415fe550ecd740f99fe2882323a58b1ce"
+        ]
+      },
+      "overrides": [],
+      "dependencies": [
+        "graceful-fs@4.2.6@d41d8cd9", "glob-to-regexp@0.4.1@d41d8cd9"
+      ],
+      "devDependencies": []
+    },
+    "v8-compile-cache@2.3.0@d41d8cd9": {
+      "id": "v8-compile-cache@2.3.0@d41d8cd9",
+      "name": "v8-compile-cache",
+      "version": "2.3.0",
+      "source": {
+        "type": "install",
+        "source": [
+          "archive:https://registry.npmjs.org/v8-compile-cache/-/v8-compile-cache-2.3.0.tgz#sha1:2de19618c66dc247dcfb6f99338035d8245a2cee"
+        ]
+      },
+      "overrides": [],
+      "dependencies": [],
+      "devDependencies": []
+    },
     "util-deprecate@1.0.2@d41d8cd9": {
       "id": "util-deprecate@1.0.2@d41d8cd9",
       "name": "util-deprecate",
@@ -44,6 +198,20 @@
       },
       "overrides": [],
       "dependencies": [],
+      "devDependencies": []
+    },
+    "uri-js@4.4.1@d41d8cd9": {
+      "id": "uri-js@4.4.1@d41d8cd9",
+      "name": "uri-js",
+      "version": "4.4.1",
+      "source": {
+        "type": "install",
+        "source": [
+          "archive:https://registry.npmjs.org/uri-js/-/uri-js-4.4.1.tgz#sha1:9b1a52595225859e55f669d928f88c6c57f2a77e"
+        ]
+      },
+      "overrides": [],
+      "dependencies": [ "punycode@2.1.1@d41d8cd9" ],
       "devDependencies": []
     },
     "typedarray-to-buffer@4.0.0@d41d8cd9": {
@@ -88,6 +256,70 @@
       "dependencies": [ "is-number@7.0.0@d41d8cd9" ],
       "devDependencies": []
     },
+    "terser-webpack-plugin@5.1.4@d41d8cd9": {
+      "id": "terser-webpack-plugin@5.1.4@d41d8cd9",
+      "name": "terser-webpack-plugin",
+      "version": "5.1.4",
+      "source": {
+        "type": "install",
+        "source": [
+          "archive:https://registry.npmjs.org/terser-webpack-plugin/-/terser-webpack-plugin-5.1.4.tgz#sha1:c369cf8a47aa9922bd0d8a94fe3d3da11a7678a1"
+        ]
+      },
+      "overrides": [],
+      "dependencies": [
+        "webpack@5.47.1@d41d8cd9", "terser@5.7.1@d41d8cd9",
+        "source-map@0.6.1@d41d8cd9", "serialize-javascript@6.0.0@d41d8cd9",
+        "schema-utils@3.1.1@d41d8cd9", "p-limit@3.1.0@d41d8cd9",
+        "jest-worker@27.0.6@d41d8cd9"
+      ],
+      "devDependencies": []
+    },
+    "terser@5.7.1@d41d8cd9": {
+      "id": "terser@5.7.1@d41d8cd9",
+      "name": "terser",
+      "version": "5.7.1",
+      "source": {
+        "type": "install",
+        "source": [
+          "archive:https://registry.npmjs.org/terser/-/terser-5.7.1.tgz#sha1:2dc7a61009b66bb638305cb2a824763b116bf784"
+        ]
+      },
+      "overrides": [],
+      "dependencies": [
+        "source-map-support@0.5.19@d41d8cd9", "source-map@0.7.3@d41d8cd9",
+        "commander@2.20.3@d41d8cd9"
+      ],
+      "devDependencies": []
+    },
+    "tapable@2.2.0@d41d8cd9": {
+      "id": "tapable@2.2.0@d41d8cd9",
+      "name": "tapable",
+      "version": "2.2.0",
+      "source": {
+        "type": "install",
+        "source": [
+          "archive:https://registry.npmjs.org/tapable/-/tapable-2.2.0.tgz#sha1:5c373d281d9c672848213d0e037d1c4165ab426b"
+        ]
+      },
+      "overrides": [],
+      "dependencies": [],
+      "devDependencies": []
+    },
+    "supports-color@8.1.1@d41d8cd9": {
+      "id": "supports-color@8.1.1@d41d8cd9",
+      "name": "supports-color",
+      "version": "8.1.1",
+      "source": {
+        "type": "install",
+        "source": [
+          "archive:https://registry.npmjs.org/supports-color/-/supports-color-8.1.1.tgz#sha1:cd6fc17e28500cff56c1b86c0a7fd4a54a73005c"
+        ]
+      },
+      "overrides": [],
+      "dependencies": [ "has-flag@4.0.0@d41d8cd9" ],
+      "devDependencies": []
+    },
     "supports-color@7.2.0@d41d8cd9": {
       "id": "supports-color@7.2.0@d41d8cd9",
       "name": "supports-color",
@@ -114,6 +346,20 @@
       },
       "overrides": [],
       "dependencies": [ "has-flag@3.0.0@d41d8cd9" ],
+      "devDependencies": []
+    },
+    "strip-final-newline@2.0.0@d41d8cd9": {
+      "id": "strip-final-newline@2.0.0@d41d8cd9",
+      "name": "strip-final-newline",
+      "version": "2.0.0",
+      "source": {
+        "type": "install",
+        "source": [
+          "archive:https://registry.npmjs.org/strip-final-newline/-/strip-final-newline-2.0.0.tgz#sha1:89b852fb2fcbe936f6f4b3187afb0a12c1ab58ad"
+        ]
+      },
+      "overrides": [],
+      "dependencies": [],
       "devDependencies": []
     },
     "string_decoder@1.3.0@d41d8cd9": {
@@ -144,6 +390,50 @@
       "dependencies": [ "escape-string-regexp@2.0.0@d41d8cd9" ],
       "devDependencies": []
     },
+    "source-map-support@0.5.19@d41d8cd9": {
+      "id": "source-map-support@0.5.19@d41d8cd9",
+      "name": "source-map-support",
+      "version": "0.5.19",
+      "source": {
+        "type": "install",
+        "source": [
+          "archive:https://registry.npmjs.org/source-map-support/-/source-map-support-0.5.19.tgz#sha1:a98b62f86dcaf4f67399648c085291ab9e8fed61"
+        ]
+      },
+      "overrides": [],
+      "dependencies": [
+        "source-map@0.6.1@d41d8cd9", "buffer-from@1.1.2@d41d8cd9"
+      ],
+      "devDependencies": []
+    },
+    "source-map@0.7.3@d41d8cd9": {
+      "id": "source-map@0.7.3@d41d8cd9",
+      "name": "source-map",
+      "version": "0.7.3",
+      "source": {
+        "type": "install",
+        "source": [
+          "archive:https://registry.npmjs.org/source-map/-/source-map-0.7.3.tgz#sha1:5302f8169031735226544092e64981f751750383"
+        ]
+      },
+      "overrides": [],
+      "dependencies": [],
+      "devDependencies": []
+    },
+    "source-map@0.6.1@d41d8cd9": {
+      "id": "source-map@0.6.1@d41d8cd9",
+      "name": "source-map",
+      "version": "0.6.1",
+      "source": {
+        "type": "install",
+        "source": [
+          "archive:https://registry.npmjs.org/source-map/-/source-map-0.6.1.tgz#sha1:74722af32e9614e9c287a8d0bbde48b5e2f1a263"
+        ]
+      },
+      "overrides": [],
+      "dependencies": [],
+      "devDependencies": []
+    },
     "slash@3.0.0@d41d8cd9": {
       "id": "slash@3.0.0@d41d8cd9",
       "name": "slash",
@@ -152,6 +442,20 @@
         "type": "install",
         "source": [
           "archive:https://registry.npmjs.org/slash/-/slash-3.0.0.tgz#sha1:6539be870c165adbd5240220dbe361f1bc4d4634"
+        ]
+      },
+      "overrides": [],
+      "dependencies": [],
+      "devDependencies": []
+    },
+    "signal-exit@3.0.3@d41d8cd9": {
+      "id": "signal-exit@3.0.3@d41d8cd9",
+      "name": "signal-exit",
+      "version": "3.0.3",
+      "source": {
+        "type": "install",
+        "source": [
+          "archive:https://registry.npmjs.org/signal-exit/-/signal-exit-3.0.3.tgz#sha1:a1410c2edd8f077b08b4e253c8eacfcaf057461c"
         ]
       },
       "overrides": [],
@@ -169,6 +473,7 @@
       },
       "overrides": [],
       "dependencies": [
+        "webpack-cli@4.7.2@d41d8cd9", "webpack@5.47.1@d41d8cd9",
         "ocaml@github:esy-ocaml/ocaml#7af70dea28d218eb53bce7966e24dfe6762862ae@d41d8cd9",
         "@taquito/taquito@9.2.0@d41d8cd9", "@taquito/signer@9.2.0@d41d8cd9",
         "@opam/tezos-micheline@opam:8.3@f8cfe30f",
@@ -193,6 +498,48 @@
         "@opam/ocaml-lsp-server@opam:1.7.0@2cdbe0ed"
       ]
     },
+    "shebang-regex@3.0.0@d41d8cd9": {
+      "id": "shebang-regex@3.0.0@d41d8cd9",
+      "name": "shebang-regex",
+      "version": "3.0.0",
+      "source": {
+        "type": "install",
+        "source": [
+          "archive:https://registry.npmjs.org/shebang-regex/-/shebang-regex-3.0.0.tgz#sha1:ae16f1644d873ecad843b0307b143362d4c42172"
+        ]
+      },
+      "overrides": [],
+      "dependencies": [],
+      "devDependencies": []
+    },
+    "shebang-command@2.0.0@d41d8cd9": {
+      "id": "shebang-command@2.0.0@d41d8cd9",
+      "name": "shebang-command",
+      "version": "2.0.0",
+      "source": {
+        "type": "install",
+        "source": [
+          "archive:https://registry.npmjs.org/shebang-command/-/shebang-command-2.0.0.tgz#sha1:ccd0af4f8835fbdc265b82461aaf0c36663f34ea"
+        ]
+      },
+      "overrides": [],
+      "dependencies": [ "shebang-regex@3.0.0@d41d8cd9" ],
+      "devDependencies": []
+    },
+    "shallow-clone@3.0.1@d41d8cd9": {
+      "id": "shallow-clone@3.0.1@d41d8cd9",
+      "name": "shallow-clone",
+      "version": "3.0.1",
+      "source": {
+        "type": "install",
+        "source": [
+          "archive:https://registry.npmjs.org/shallow-clone/-/shallow-clone-3.0.1.tgz#sha1:8f2981ad92531f55035b01fb230769a40e02efa3"
+        ]
+      },
+      "overrides": [],
+      "dependencies": [ "kind-of@6.0.3@d41d8cd9" ],
+      "devDependencies": []
+    },
     "sha.js@2.4.11@d41d8cd9": {
       "id": "sha.js@2.4.11@d41d8cd9",
       "name": "sha.js",
@@ -206,6 +553,37 @@
       "overrides": [],
       "dependencies": [
         "safe-buffer@5.2.1@d41d8cd9", "inherits@2.0.4@d41d8cd9"
+      ],
+      "devDependencies": []
+    },
+    "serialize-javascript@6.0.0@d41d8cd9": {
+      "id": "serialize-javascript@6.0.0@d41d8cd9",
+      "name": "serialize-javascript",
+      "version": "6.0.0",
+      "source": {
+        "type": "install",
+        "source": [
+          "archive:https://registry.npmjs.org/serialize-javascript/-/serialize-javascript-6.0.0.tgz#sha1:efae5d88f45d7924141da8b5c3a7a7e663fefeb8"
+        ]
+      },
+      "overrides": [],
+      "dependencies": [ "randombytes@2.1.0@d41d8cd9" ],
+      "devDependencies": []
+    },
+    "schema-utils@3.1.1@d41d8cd9": {
+      "id": "schema-utils@3.1.1@d41d8cd9",
+      "name": "schema-utils",
+      "version": "3.1.1",
+      "source": {
+        "type": "install",
+        "source": [
+          "archive:https://registry.npmjs.org/schema-utils/-/schema-utils-3.1.1.tgz#sha1:bc74c4b6b6995c1d88f76a8b77bea7219e0c8281"
+        ]
+      },
+      "overrides": [],
+      "dependencies": [
+        "ajv-keywords@3.5.2@d41d8cd9", "ajv@6.12.6@d41d8cd9",
+        "@types/json-schema@7.0.8@d41d8cd9"
       ],
       "devDependencies": []
     },
@@ -270,6 +648,64 @@
       ],
       "devDependencies": []
     },
+    "resolve-from@5.0.0@d41d8cd9": {
+      "id": "resolve-from@5.0.0@d41d8cd9",
+      "name": "resolve-from",
+      "version": "5.0.0",
+      "source": {
+        "type": "install",
+        "source": [
+          "archive:https://registry.npmjs.org/resolve-from/-/resolve-from-5.0.0.tgz#sha1:c35225843df8f776df21c57557bc087e9dfdfc69"
+        ]
+      },
+      "overrides": [],
+      "dependencies": [],
+      "devDependencies": []
+    },
+    "resolve-cwd@3.0.0@d41d8cd9": {
+      "id": "resolve-cwd@3.0.0@d41d8cd9",
+      "name": "resolve-cwd",
+      "version": "3.0.0",
+      "source": {
+        "type": "install",
+        "source": [
+          "archive:https://registry.npmjs.org/resolve-cwd/-/resolve-cwd-3.0.0.tgz#sha1:0f0075f1bb2544766cf73ba6a6e2adfebcb13f2d"
+        ]
+      },
+      "overrides": [],
+      "dependencies": [ "resolve-from@5.0.0@d41d8cd9" ],
+      "devDependencies": []
+    },
+    "resolve@1.20.0@d41d8cd9": {
+      "id": "resolve@1.20.0@d41d8cd9",
+      "name": "resolve",
+      "version": "1.20.0",
+      "source": {
+        "type": "install",
+        "source": [
+          "archive:https://registry.npmjs.org/resolve/-/resolve-1.20.0.tgz#sha1:629a013fb3f70755d6f0b7935cc1c2c5378b1975"
+        ]
+      },
+      "overrides": [],
+      "dependencies": [
+        "path-parse@1.0.7@d41d8cd9", "is-core-module@2.5.0@d41d8cd9"
+      ],
+      "devDependencies": []
+    },
+    "rechoir@0.7.1@d41d8cd9": {
+      "id": "rechoir@0.7.1@d41d8cd9",
+      "name": "rechoir",
+      "version": "0.7.1",
+      "source": {
+        "type": "install",
+        "source": [
+          "archive:https://registry.npmjs.org/rechoir/-/rechoir-0.7.1.tgz#sha1:9478a96a1ca135b5e88fc027f03ee92d6c645686"
+        ]
+      },
+      "overrides": [],
+      "dependencies": [ "resolve@1.20.0@d41d8cd9" ],
+      "devDependencies": []
+    },
     "readable-stream@3.6.0@d41d8cd9": {
       "id": "readable-stream@3.6.0@d41d8cd9",
       "name": "readable-stream",
@@ -315,6 +751,20 @@
       "dependencies": [ "safe-buffer@5.2.1@d41d8cd9" ],
       "devDependencies": []
     },
+    "punycode@2.1.1@d41d8cd9": {
+      "id": "punycode@2.1.1@d41d8cd9",
+      "name": "punycode",
+      "version": "2.1.1",
+      "source": {
+        "type": "install",
+        "source": [
+          "archive:https://registry.npmjs.org/punycode/-/punycode-2.1.1.tgz#sha1:b58b010ac40c22c5657616c8d2c2c02c7bf479ec"
+        ]
+      },
+      "overrides": [],
+      "dependencies": [],
+      "devDependencies": []
+    },
     "pretty-format@26.6.2@d41d8cd9": {
       "id": "pretty-format@26.6.2@d41d8cd9",
       "name": "pretty-format",
@@ -330,6 +780,20 @@
         "react-is@17.0.2@d41d8cd9", "ansi-styles@4.3.0@d41d8cd9",
         "ansi-regex@5.0.0@d41d8cd9", "@jest/types@26.6.2@d41d8cd9"
       ],
+      "devDependencies": []
+    },
+    "pkg-dir@4.2.0@d41d8cd9": {
+      "id": "pkg-dir@4.2.0@d41d8cd9",
+      "name": "pkg-dir",
+      "version": "4.2.0",
+      "source": {
+        "type": "install",
+        "source": [
+          "archive:https://registry.npmjs.org/pkg-dir/-/pkg-dir-4.2.0.tgz#sha1:f099133df7ede422e81d1d8448270eeb3e4261f3"
+        ]
+      },
+      "overrides": [],
+      "dependencies": [ "find-up@4.1.0@d41d8cd9" ],
       "devDependencies": []
     },
     "picomatch@2.3.0@d41d8cd9": {
@@ -364,6 +828,118 @@
       ],
       "devDependencies": []
     },
+    "path-parse@1.0.7@d41d8cd9": {
+      "id": "path-parse@1.0.7@d41d8cd9",
+      "name": "path-parse",
+      "version": "1.0.7",
+      "source": {
+        "type": "install",
+        "source": [
+          "archive:https://registry.npmjs.org/path-parse/-/path-parse-1.0.7.tgz#sha1:fbc114b60ca42b30d9daf5858e4bd68bbedb6735"
+        ]
+      },
+      "overrides": [],
+      "dependencies": [],
+      "devDependencies": []
+    },
+    "path-key@3.1.1@d41d8cd9": {
+      "id": "path-key@3.1.1@d41d8cd9",
+      "name": "path-key",
+      "version": "3.1.1",
+      "source": {
+        "type": "install",
+        "source": [
+          "archive:https://registry.npmjs.org/path-key/-/path-key-3.1.1.tgz#sha1:581f6ade658cbba65a0d3380de7753295054f375"
+        ]
+      },
+      "overrides": [],
+      "dependencies": [],
+      "devDependencies": []
+    },
+    "path-exists@4.0.0@d41d8cd9": {
+      "id": "path-exists@4.0.0@d41d8cd9",
+      "name": "path-exists",
+      "version": "4.0.0",
+      "source": {
+        "type": "install",
+        "source": [
+          "archive:https://registry.npmjs.org/path-exists/-/path-exists-4.0.0.tgz#sha1:513bdbe2d3b95d7762e8c1137efa195c6c61b5b3"
+        ]
+      },
+      "overrides": [],
+      "dependencies": [],
+      "devDependencies": []
+    },
+    "p-try@2.2.0@d41d8cd9": {
+      "id": "p-try@2.2.0@d41d8cd9",
+      "name": "p-try",
+      "version": "2.2.0",
+      "source": {
+        "type": "install",
+        "source": [
+          "archive:https://registry.npmjs.org/p-try/-/p-try-2.2.0.tgz#sha1:cb2868540e313d61de58fafbe35ce9004d5540e6"
+        ]
+      },
+      "overrides": [],
+      "dependencies": [],
+      "devDependencies": []
+    },
+    "p-locate@4.1.0@d41d8cd9": {
+      "id": "p-locate@4.1.0@d41d8cd9",
+      "name": "p-locate",
+      "version": "4.1.0",
+      "source": {
+        "type": "install",
+        "source": [
+          "archive:https://registry.npmjs.org/p-locate/-/p-locate-4.1.0.tgz#sha1:a3428bb7088b3a60292f66919278b7c297ad4f07"
+        ]
+      },
+      "overrides": [],
+      "dependencies": [ "p-limit@2.3.0@d41d8cd9" ],
+      "devDependencies": []
+    },
+    "p-limit@3.1.0@d41d8cd9": {
+      "id": "p-limit@3.1.0@d41d8cd9",
+      "name": "p-limit",
+      "version": "3.1.0",
+      "source": {
+        "type": "install",
+        "source": [
+          "archive:https://registry.npmjs.org/p-limit/-/p-limit-3.1.0.tgz#sha1:e1daccbe78d0d1388ca18c64fea38e3e57e3706b"
+        ]
+      },
+      "overrides": [],
+      "dependencies": [ "yocto-queue@0.1.0@d41d8cd9" ],
+      "devDependencies": []
+    },
+    "p-limit@2.3.0@d41d8cd9": {
+      "id": "p-limit@2.3.0@d41d8cd9",
+      "name": "p-limit",
+      "version": "2.3.0",
+      "source": {
+        "type": "install",
+        "source": [
+          "archive:https://registry.npmjs.org/p-limit/-/p-limit-2.3.0.tgz#sha1:3dd33c647a214fdfffd835933eb086da0dc21db1"
+        ]
+      },
+      "overrides": [],
+      "dependencies": [ "p-try@2.2.0@d41d8cd9" ],
+      "devDependencies": []
+    },
+    "onetime@5.1.2@d41d8cd9": {
+      "id": "onetime@5.1.2@d41d8cd9",
+      "name": "onetime",
+      "version": "5.1.2",
+      "source": {
+        "type": "install",
+        "source": [
+          "archive:https://registry.npmjs.org/onetime/-/onetime-5.1.2.tgz#sha1:d0e96ebb56b07476df1dd9c4806e5237985ca45e"
+        ]
+      },
+      "overrides": [],
+      "dependencies": [ "mimic-fn@2.1.0@d41d8cd9" ],
+      "devDependencies": []
+    },
     "ocaml@github:esy-ocaml/ocaml#7af70dea28d218eb53bce7966e24dfe6762862ae@d41d8cd9": {
       "id":
         "ocaml@github:esy-ocaml/ocaml#7af70dea28d218eb53bce7966e24dfe6762862ae@d41d8cd9",
@@ -374,6 +950,48 @@
         "type": "install",
         "source": [
           "github:esy-ocaml/ocaml#7af70dea28d218eb53bce7966e24dfe6762862ae"
+        ]
+      },
+      "overrides": [],
+      "dependencies": [],
+      "devDependencies": []
+    },
+    "npm-run-path@4.0.1@d41d8cd9": {
+      "id": "npm-run-path@4.0.1@d41d8cd9",
+      "name": "npm-run-path",
+      "version": "4.0.1",
+      "source": {
+        "type": "install",
+        "source": [
+          "archive:https://registry.npmjs.org/npm-run-path/-/npm-run-path-4.0.1.tgz#sha1:b7ecd1e5ed53da8e37a55e1c2269e0b97ed748ea"
+        ]
+      },
+      "overrides": [],
+      "dependencies": [ "path-key@3.1.1@d41d8cd9" ],
+      "devDependencies": []
+    },
+    "node-releases@1.1.73@d41d8cd9": {
+      "id": "node-releases@1.1.73@d41d8cd9",
+      "name": "node-releases",
+      "version": "1.1.73",
+      "source": {
+        "type": "install",
+        "source": [
+          "archive:https://registry.npmjs.org/node-releases/-/node-releases-1.1.73.tgz#sha1:dd4e81ddd5277ff846b80b52bb40c49edf7a7b20"
+        ]
+      },
+      "overrides": [],
+      "dependencies": [],
+      "devDependencies": []
+    },
+    "neo-async@2.6.2@d41d8cd9": {
+      "id": "neo-async@2.6.2@d41d8cd9",
+      "name": "neo-async",
+      "version": "2.6.2",
+      "source": {
+        "type": "install",
+        "source": [
+          "archive:https://registry.npmjs.org/neo-async/-/neo-async-2.6.2.tgz#sha1:b4aafb93e3aeb2d8174ca53cf163ab7d7308305f"
         ]
       },
       "overrides": [],
@@ -408,6 +1026,48 @@
       "dependencies": [],
       "devDependencies": []
     },
+    "mimic-fn@2.1.0@d41d8cd9": {
+      "id": "mimic-fn@2.1.0@d41d8cd9",
+      "name": "mimic-fn",
+      "version": "2.1.0",
+      "source": {
+        "type": "install",
+        "source": [
+          "archive:https://registry.npmjs.org/mimic-fn/-/mimic-fn-2.1.0.tgz#sha1:7ed2c2ccccaf84d3ffcb7a69b57711fc2083401b"
+        ]
+      },
+      "overrides": [],
+      "dependencies": [],
+      "devDependencies": []
+    },
+    "mime-types@2.1.32@d41d8cd9": {
+      "id": "mime-types@2.1.32@d41d8cd9",
+      "name": "mime-types",
+      "version": "2.1.32",
+      "source": {
+        "type": "install",
+        "source": [
+          "archive:https://registry.npmjs.org/mime-types/-/mime-types-2.1.32.tgz#sha1:1d00e89e7de7fe02008db61001d9e02852670fd5"
+        ]
+      },
+      "overrides": [],
+      "dependencies": [ "mime-db@1.49.0@d41d8cd9" ],
+      "devDependencies": []
+    },
+    "mime-db@1.49.0@d41d8cd9": {
+      "id": "mime-db@1.49.0@d41d8cd9",
+      "name": "mime-db",
+      "version": "1.49.0",
+      "source": {
+        "type": "install",
+        "source": [
+          "archive:https://registry.npmjs.org/mime-db/-/mime-db-1.49.0.tgz#sha1:f3dfde60c99e9cf3bc9701d687778f537001cbed"
+        ]
+      },
+      "overrides": [],
+      "dependencies": [],
+      "devDependencies": []
+    },
     "micromatch@4.0.4@d41d8cd9": {
       "id": "micromatch@4.0.4@d41d8cd9",
       "name": "micromatch",
@@ -420,6 +1080,20 @@
       },
       "overrides": [],
       "dependencies": [ "picomatch@2.3.0@d41d8cd9", "braces@3.0.2@d41d8cd9" ],
+      "devDependencies": []
+    },
+    "merge-stream@2.0.0@d41d8cd9": {
+      "id": "merge-stream@2.0.0@d41d8cd9",
+      "name": "merge-stream",
+      "version": "2.0.0",
+      "source": {
+        "type": "install",
+        "source": [
+          "archive:https://registry.npmjs.org/merge-stream/-/merge-stream-2.0.0.tgz#sha1:52823629a14dd00c9770fb6ad47dc6310f2c1f60"
+        ]
+      },
+      "overrides": [],
+      "dependencies": [],
       "devDependencies": []
     },
     "md5.js@1.3.5@d41d8cd9": {
@@ -447,6 +1121,34 @@
         "type": "install",
         "source": [
           "archive:https://registry.npmjs.org/lodash/-/lodash-4.17.21.tgz#sha1:679591c564c3bffaae8454cf0b3df370c3d6911c"
+        ]
+      },
+      "overrides": [],
+      "dependencies": [],
+      "devDependencies": []
+    },
+    "locate-path@5.0.0@d41d8cd9": {
+      "id": "locate-path@5.0.0@d41d8cd9",
+      "name": "locate-path",
+      "version": "5.0.0",
+      "source": {
+        "type": "install",
+        "source": [
+          "archive:https://registry.npmjs.org/locate-path/-/locate-path-5.0.0.tgz#sha1:1afba396afd676a6d42504d0a67a3a7eb9f62aa0"
+        ]
+      },
+      "overrides": [],
+      "dependencies": [ "p-locate@4.1.0@d41d8cd9" ],
+      "devDependencies": []
+    },
+    "loader-runner@4.2.0@d41d8cd9": {
+      "id": "loader-runner@4.2.0@d41d8cd9",
+      "name": "loader-runner",
+      "version": "4.2.0",
+      "source": {
+        "type": "install",
+        "source": [
+          "archive:https://registry.npmjs.org/loader-runner/-/loader-runner-4.2.0.tgz#sha1:d7022380d66d14c5fb1d496b89864ebcfd478384"
         ]
       },
       "overrides": [],
@@ -481,6 +1183,48 @@
       "dependencies": [],
       "devDependencies": []
     },
+    "kind-of@6.0.3@d41d8cd9": {
+      "id": "kind-of@6.0.3@d41d8cd9",
+      "name": "kind-of",
+      "version": "6.0.3",
+      "source": {
+        "type": "install",
+        "source": [
+          "archive:https://registry.npmjs.org/kind-of/-/kind-of-6.0.3.tgz#sha1:07c05034a6c349fa06e24fa35aa76db4580ce4dd"
+        ]
+      },
+      "overrides": [],
+      "dependencies": [],
+      "devDependencies": []
+    },
+    "json-schema-traverse@0.4.1@d41d8cd9": {
+      "id": "json-schema-traverse@0.4.1@d41d8cd9",
+      "name": "json-schema-traverse",
+      "version": "0.4.1",
+      "source": {
+        "type": "install",
+        "source": [
+          "archive:https://registry.npmjs.org/json-schema-traverse/-/json-schema-traverse-0.4.1.tgz#sha1:69f6a87d9513ab8bb8fe63bdb0979c448e684660"
+        ]
+      },
+      "overrides": [],
+      "dependencies": [],
+      "devDependencies": []
+    },
+    "json-parse-better-errors@1.0.2@d41d8cd9": {
+      "id": "json-parse-better-errors@1.0.2@d41d8cd9",
+      "name": "json-parse-better-errors",
+      "version": "1.0.2",
+      "source": {
+        "type": "install",
+        "source": [
+          "archive:https://registry.npmjs.org/json-parse-better-errors/-/json-parse-better-errors-1.0.2.tgz#sha1:bb867cfb3450e69107c131d1c514bab3dc8bcaa9"
+        ]
+      },
+      "overrides": [],
+      "dependencies": [],
+      "devDependencies": []
+    },
     "js-tokens@4.0.0@d41d8cd9": {
       "id": "js-tokens@4.0.0@d41d8cd9",
       "name": "js-tokens",
@@ -493,6 +1237,23 @@
       },
       "overrides": [],
       "dependencies": [],
+      "devDependencies": []
+    },
+    "jest-worker@27.0.6@d41d8cd9": {
+      "id": "jest-worker@27.0.6@d41d8cd9",
+      "name": "jest-worker",
+      "version": "27.0.6",
+      "source": {
+        "type": "install",
+        "source": [
+          "archive:https://registry.npmjs.org/jest-worker/-/jest-worker-27.0.6.tgz#sha1:a5fdb1e14ad34eb228cfe162d9f729cdbfa28aed"
+        ]
+      },
+      "overrides": [],
+      "dependencies": [
+        "supports-color@8.1.1@d41d8cd9", "merge-stream@2.0.0@d41d8cd9",
+        "@types/node@11.11.6@d41d8cd9"
+      ],
       "devDependencies": []
     },
     "jest-regex-util@26.0.0@d41d8cd9": {
@@ -577,6 +1338,62 @@
       ],
       "devDependencies": []
     },
+    "isobject@3.0.1@d41d8cd9": {
+      "id": "isobject@3.0.1@d41d8cd9",
+      "name": "isobject",
+      "version": "3.0.1",
+      "source": {
+        "type": "install",
+        "source": [
+          "archive:https://registry.npmjs.org/isobject/-/isobject-3.0.1.tgz#sha1:4e431e92b11a9731636aa1f9c8d1ccbcfdab78df"
+        ]
+      },
+      "overrides": [],
+      "dependencies": [],
+      "devDependencies": []
+    },
+    "isexe@2.0.0@d41d8cd9": {
+      "id": "isexe@2.0.0@d41d8cd9",
+      "name": "isexe",
+      "version": "2.0.0",
+      "source": {
+        "type": "install",
+        "source": [
+          "archive:https://registry.npmjs.org/isexe/-/isexe-2.0.0.tgz#sha1:e8fbf374dc556ff8947a10dcb0572d633f2cfa10"
+        ]
+      },
+      "overrides": [],
+      "dependencies": [],
+      "devDependencies": []
+    },
+    "is-stream@2.0.1@d41d8cd9": {
+      "id": "is-stream@2.0.1@d41d8cd9",
+      "name": "is-stream",
+      "version": "2.0.1",
+      "source": {
+        "type": "install",
+        "source": [
+          "archive:https://registry.npmjs.org/is-stream/-/is-stream-2.0.1.tgz#sha1:fac1e3d53b97ad5a9d0ae9cef2389f5810a5c077"
+        ]
+      },
+      "overrides": [],
+      "dependencies": [],
+      "devDependencies": []
+    },
+    "is-plain-object@2.0.4@d41d8cd9": {
+      "id": "is-plain-object@2.0.4@d41d8cd9",
+      "name": "is-plain-object",
+      "version": "2.0.4",
+      "source": {
+        "type": "install",
+        "source": [
+          "archive:https://registry.npmjs.org/is-plain-object/-/is-plain-object-2.0.4.tgz#sha1:2c163b3fafb1b606d9d17928f05c2a1c38e07677"
+        ]
+      },
+      "overrides": [],
+      "dependencies": [ "isobject@3.0.1@d41d8cd9" ],
+      "devDependencies": []
+    },
     "is-number@7.0.0@d41d8cd9": {
       "id": "is-number@7.0.0@d41d8cd9",
       "name": "is-number",
@@ -585,6 +1402,34 @@
         "type": "install",
         "source": [
           "archive:https://registry.npmjs.org/is-number/-/is-number-7.0.0.tgz#sha1:7535345b896734d5f80c4d06c50955527a14f12b"
+        ]
+      },
+      "overrides": [],
+      "dependencies": [],
+      "devDependencies": []
+    },
+    "is-core-module@2.5.0@d41d8cd9": {
+      "id": "is-core-module@2.5.0@d41d8cd9",
+      "name": "is-core-module",
+      "version": "2.5.0",
+      "source": {
+        "type": "install",
+        "source": [
+          "archive:https://registry.npmjs.org/is-core-module/-/is-core-module-2.5.0.tgz#sha1:f754843617c70bfd29b7bd87327400cda5c18491"
+        ]
+      },
+      "overrides": [],
+      "dependencies": [ "has@1.0.3@d41d8cd9" ],
+      "devDependencies": []
+    },
+    "interpret@2.2.0@d41d8cd9": {
+      "id": "interpret@2.2.0@d41d8cd9",
+      "name": "interpret",
+      "version": "2.2.0",
+      "source": {
+        "type": "install",
+        "source": [
+          "archive:https://registry.npmjs.org/interpret/-/interpret-2.2.0.tgz#sha1:1a78a0b5965c40a5416d007ad6f50ad27c417df9"
         ]
       },
       "overrides": [],
@@ -605,6 +1450,22 @@
       "dependencies": [],
       "devDependencies": []
     },
+    "import-local@3.0.2@d41d8cd9": {
+      "id": "import-local@3.0.2@d41d8cd9",
+      "name": "import-local",
+      "version": "3.0.2",
+      "source": {
+        "type": "install",
+        "source": [
+          "archive:https://registry.npmjs.org/import-local/-/import-local-3.0.2.tgz#sha1:a8cfd0431d1de4a2199703d003e3e62364fa6db6"
+        ]
+      },
+      "overrides": [],
+      "dependencies": [
+        "resolve-cwd@3.0.0@d41d8cd9", "pkg-dir@4.2.0@d41d8cd9"
+      ],
+      "devDependencies": []
+    },
     "ieee754@1.2.1@d41d8cd9": {
       "id": "ieee754@1.2.1@d41d8cd9",
       "name": "ieee754",
@@ -613,6 +1474,20 @@
         "type": "install",
         "source": [
           "archive:https://registry.npmjs.org/ieee754/-/ieee754-1.2.1.tgz#sha1:8eb7a10a63fff25d15a57b001586d177d1b0d352"
+        ]
+      },
+      "overrides": [],
+      "dependencies": [],
+      "devDependencies": []
+    },
+    "human-signals@2.1.0@d41d8cd9": {
+      "id": "human-signals@2.1.0@d41d8cd9",
+      "name": "human-signals",
+      "version": "2.1.0",
+      "source": {
+        "type": "install",
+        "source": [
+          "archive:https://registry.npmjs.org/human-signals/-/human-signals-2.1.0.tgz#sha1:dc91fcba42e4d06e4abaed33b3e7a3c02f514ea0"
         ]
       },
       "overrides": [],
@@ -697,6 +1572,20 @@
       "dependencies": [],
       "devDependencies": []
     },
+    "has@1.0.3@d41d8cd9": {
+      "id": "has@1.0.3@d41d8cd9",
+      "name": "has",
+      "version": "1.0.3",
+      "source": {
+        "type": "install",
+        "source": [
+          "archive:https://registry.npmjs.org/has/-/has-1.0.3.tgz#sha1:722d7cbfc1f6aa8241f16dd814e011e1f41e8796"
+        ]
+      },
+      "overrides": [],
+      "dependencies": [ "function-bind@1.1.1@d41d8cd9" ],
+      "devDependencies": []
+    },
     "graceful-fs@4.2.6@d41d8cd9": {
       "id": "graceful-fs@4.2.6@d41d8cd9",
       "name": "graceful-fs",
@@ -709,6 +1598,64 @@
       },
       "overrides": [],
       "dependencies": [],
+      "devDependencies": []
+    },
+    "glob-to-regexp@0.4.1@d41d8cd9": {
+      "id": "glob-to-regexp@0.4.1@d41d8cd9",
+      "name": "glob-to-regexp",
+      "version": "0.4.1",
+      "source": {
+        "type": "install",
+        "source": [
+          "archive:https://registry.npmjs.org/glob-to-regexp/-/glob-to-regexp-0.4.1.tgz#sha1:c75297087c851b9a578bd217dd59a92f59fe546e"
+        ]
+      },
+      "overrides": [],
+      "dependencies": [],
+      "devDependencies": []
+    },
+    "get-stream@6.0.1@d41d8cd9": {
+      "id": "get-stream@6.0.1@d41d8cd9",
+      "name": "get-stream",
+      "version": "6.0.1",
+      "source": {
+        "type": "install",
+        "source": [
+          "archive:https://registry.npmjs.org/get-stream/-/get-stream-6.0.1.tgz#sha1:a262d8eef67aced57c2852ad6167526a43cbf7b7"
+        ]
+      },
+      "overrides": [],
+      "dependencies": [],
+      "devDependencies": []
+    },
+    "function-bind@1.1.1@d41d8cd9": {
+      "id": "function-bind@1.1.1@d41d8cd9",
+      "name": "function-bind",
+      "version": "1.1.1",
+      "source": {
+        "type": "install",
+        "source": [
+          "archive:https://registry.npmjs.org/function-bind/-/function-bind-1.1.1.tgz#sha1:a56899d3ea3c9bab874bb9773b7c5ede92f4895d"
+        ]
+      },
+      "overrides": [],
+      "dependencies": [],
+      "devDependencies": []
+    },
+    "find-up@4.1.0@d41d8cd9": {
+      "id": "find-up@4.1.0@d41d8cd9",
+      "name": "find-up",
+      "version": "4.1.0",
+      "source": {
+        "type": "install",
+        "source": [
+          "archive:https://registry.npmjs.org/find-up/-/find-up-4.1.0.tgz#sha1:97afe7d6cdc0bc5928584b7c8d7b16e8a9aa5d19"
+        ]
+      },
+      "overrides": [],
+      "dependencies": [
+        "path-exists@4.0.0@d41d8cd9", "locate-path@5.0.0@d41d8cd9"
+      ],
       "devDependencies": []
     },
     "fill-range@7.0.1@d41d8cd9": {
@@ -725,6 +1672,20 @@
       "dependencies": [ "to-regex-range@5.0.1@d41d8cd9" ],
       "devDependencies": []
     },
+    "fastest-levenshtein@1.0.12@d41d8cd9": {
+      "id": "fastest-levenshtein@1.0.12@d41d8cd9",
+      "name": "fastest-levenshtein",
+      "version": "1.0.12",
+      "source": {
+        "type": "install",
+        "source": [
+          "archive:https://registry.npmjs.org/fastest-levenshtein/-/fastest-levenshtein-1.0.12.tgz#sha1:9990f7d3a88cc5a9ffd1f1745745251700d497e2"
+        ]
+      },
+      "overrides": [],
+      "dependencies": [],
+      "devDependencies": []
+    },
     "fast-json-stable-stringify@2.1.0@d41d8cd9": {
       "id": "fast-json-stable-stringify@2.1.0@d41d8cd9",
       "name": "fast-json-stable-stringify",
@@ -733,6 +1694,20 @@
         "type": "install",
         "source": [
           "archive:https://registry.npmjs.org/fast-json-stable-stringify/-/fast-json-stable-stringify-2.1.0.tgz#sha1:874bf69c6f404c2b5d99c481341399fd55892633"
+        ]
+      },
+      "overrides": [],
+      "dependencies": [],
+      "devDependencies": []
+    },
+    "fast-deep-equal@3.1.3@d41d8cd9": {
+      "id": "fast-deep-equal@3.1.3@d41d8cd9",
+      "name": "fast-deep-equal",
+      "version": "3.1.3",
+      "source": {
+        "type": "install",
+        "source": [
+          "archive:https://registry.npmjs.org/fast-deep-equal/-/fast-deep-equal-3.1.3.tgz#sha1:3a7d56b559d6cbc3eb512325244e619a65c6c525"
         ]
       },
       "overrides": [],
@@ -757,6 +1732,40 @@
         "jest-get-type@26.3.0@d41d8cd9", "ansi-styles@4.3.0@d41d8cd9",
         "@jest/types@26.6.2@d41d8cd9"
       ],
+      "devDependencies": []
+    },
+    "execa@5.1.1@d41d8cd9": {
+      "id": "execa@5.1.1@d41d8cd9",
+      "name": "execa",
+      "version": "5.1.1",
+      "source": {
+        "type": "install",
+        "source": [
+          "archive:https://registry.npmjs.org/execa/-/execa-5.1.1.tgz#sha1:f80ad9cbf4298f7bd1d4c9555c21e93741c411dd"
+        ]
+      },
+      "overrides": [],
+      "dependencies": [
+        "strip-final-newline@2.0.0@d41d8cd9", "signal-exit@3.0.3@d41d8cd9",
+        "onetime@5.1.2@d41d8cd9", "npm-run-path@4.0.1@d41d8cd9",
+        "merge-stream@2.0.0@d41d8cd9", "is-stream@2.0.1@d41d8cd9",
+        "human-signals@2.1.0@d41d8cd9", "get-stream@6.0.1@d41d8cd9",
+        "cross-spawn@7.0.3@d41d8cd9"
+      ],
+      "devDependencies": []
+    },
+    "events@3.3.0@d41d8cd9": {
+      "id": "events@3.3.0@d41d8cd9",
+      "name": "events",
+      "version": "3.3.0",
+      "source": {
+        "type": "install",
+        "source": [
+          "archive:https://registry.npmjs.org/events/-/events-3.3.0.tgz#sha1:31a95ad0a924e2d2c419a813aeb2c4e878ea7400"
+        ]
+      },
+      "overrides": [],
+      "dependencies": [],
       "devDependencies": []
     },
     "esy-openssl@archive:https://github.com/openssl/openssl/archive/OpenSSL_1_1_1g.tar.gz#sha1:33324ff957edaae8ae575817b456320378da46ff@41b6fb3d": {
@@ -810,6 +1819,64 @@
       "dependencies": [],
       "devDependencies": []
     },
+    "estraverse@5.2.0@d41d8cd9": {
+      "id": "estraverse@5.2.0@d41d8cd9",
+      "name": "estraverse",
+      "version": "5.2.0",
+      "source": {
+        "type": "install",
+        "source": [
+          "archive:https://registry.npmjs.org/estraverse/-/estraverse-5.2.0.tgz#sha1:307df42547e6cc7324d3cf03c155d5cdb8c53880"
+        ]
+      },
+      "overrides": [],
+      "dependencies": [],
+      "devDependencies": []
+    },
+    "estraverse@4.3.0@d41d8cd9": {
+      "id": "estraverse@4.3.0@d41d8cd9",
+      "name": "estraverse",
+      "version": "4.3.0",
+      "source": {
+        "type": "install",
+        "source": [
+          "archive:https://registry.npmjs.org/estraverse/-/estraverse-4.3.0.tgz#sha1:398ad3f3c5a24948be7725e83d11a7de28cdbd1d"
+        ]
+      },
+      "overrides": [],
+      "dependencies": [],
+      "devDependencies": []
+    },
+    "esrecurse@4.3.0@d41d8cd9": {
+      "id": "esrecurse@4.3.0@d41d8cd9",
+      "name": "esrecurse",
+      "version": "4.3.0",
+      "source": {
+        "type": "install",
+        "source": [
+          "archive:https://registry.npmjs.org/esrecurse/-/esrecurse-4.3.0.tgz#sha1:7ad7964d679abb28bee72cec63758b1c5d2c9921"
+        ]
+      },
+      "overrides": [],
+      "dependencies": [ "estraverse@5.2.0@d41d8cd9" ],
+      "devDependencies": []
+    },
+    "eslint-scope@5.1.1@d41d8cd9": {
+      "id": "eslint-scope@5.1.1@d41d8cd9",
+      "name": "eslint-scope",
+      "version": "5.1.1",
+      "source": {
+        "type": "install",
+        "source": [
+          "archive:https://registry.npmjs.org/eslint-scope/-/eslint-scope-5.1.1.tgz#sha1:e786e59a66cb92b3f6c1fb0d508aab174848f48c"
+        ]
+      },
+      "overrides": [],
+      "dependencies": [
+        "estraverse@4.3.0@d41d8cd9", "esrecurse@4.3.0@d41d8cd9"
+      ],
+      "devDependencies": []
+    },
     "escape-string-regexp@2.0.0@d41d8cd9": {
       "id": "escape-string-regexp@2.0.0@d41d8cd9",
       "name": "escape-string-regexp",
@@ -838,6 +1905,64 @@
       "dependencies": [],
       "devDependencies": []
     },
+    "escalade@3.1.1@d41d8cd9": {
+      "id": "escalade@3.1.1@d41d8cd9",
+      "name": "escalade",
+      "version": "3.1.1",
+      "source": {
+        "type": "install",
+        "source": [
+          "archive:https://registry.npmjs.org/escalade/-/escalade-3.1.1.tgz#sha1:d8cfdc7000965c5a0174b4a82eaa5c0552742e40"
+        ]
+      },
+      "overrides": [],
+      "dependencies": [],
+      "devDependencies": []
+    },
+    "es-module-lexer@0.7.1@d41d8cd9": {
+      "id": "es-module-lexer@0.7.1@d41d8cd9",
+      "name": "es-module-lexer",
+      "version": "0.7.1",
+      "source": {
+        "type": "install",
+        "source": [
+          "archive:https://registry.npmjs.org/es-module-lexer/-/es-module-lexer-0.7.1.tgz#sha1:c2c8e0f46f2df06274cdaf0dd3f3b33e0a0b267d"
+        ]
+      },
+      "overrides": [],
+      "dependencies": [],
+      "devDependencies": []
+    },
+    "envinfo@7.8.1@d41d8cd9": {
+      "id": "envinfo@7.8.1@d41d8cd9",
+      "name": "envinfo",
+      "version": "7.8.1",
+      "source": {
+        "type": "install",
+        "source": [
+          "archive:https://registry.npmjs.org/envinfo/-/envinfo-7.8.1.tgz#sha1:06377e3e5f4d379fea7ac592d5ad8927e0c4d475"
+        ]
+      },
+      "overrides": [],
+      "dependencies": [],
+      "devDependencies": []
+    },
+    "enhanced-resolve@5.8.2@d41d8cd9": {
+      "id": "enhanced-resolve@5.8.2@d41d8cd9",
+      "name": "enhanced-resolve",
+      "version": "5.8.2",
+      "source": {
+        "type": "install",
+        "source": [
+          "archive:https://registry.npmjs.org/enhanced-resolve/-/enhanced-resolve-5.8.2.tgz#sha1:15ddc779345cbb73e97c611cd00c01c1e7bf4d8b"
+        ]
+      },
+      "overrides": [],
+      "dependencies": [
+        "tapable@2.2.0@d41d8cd9", "graceful-fs@4.2.6@d41d8cd9"
+      ],
+      "devDependencies": []
+    },
     "elliptic@6.5.4@d41d8cd9": {
       "id": "elliptic@6.5.4@d41d8cd9",
       "name": "elliptic",
@@ -857,6 +1982,20 @@
       ],
       "devDependencies": []
     },
+    "electron-to-chromium@1.3.792@d41d8cd9": {
+      "id": "electron-to-chromium@1.3.792@d41d8cd9",
+      "name": "electron-to-chromium",
+      "version": "1.3.792",
+      "source": {
+        "type": "install",
+        "source": [
+          "archive:https://registry.npmjs.org/electron-to-chromium/-/electron-to-chromium-1.3.792.tgz#sha1:791b0d8fcf7411885d086193fb49aaef0c1594ca"
+        ]
+      },
+      "overrides": [],
+      "dependencies": [],
+      "devDependencies": []
+    },
     "diff-sequences@26.6.2@d41d8cd9": {
       "id": "diff-sequences@26.6.2@d41d8cd9",
       "name": "diff-sequences",
@@ -869,6 +2008,23 @@
       },
       "overrides": [],
       "dependencies": [],
+      "devDependencies": []
+    },
+    "cross-spawn@7.0.3@d41d8cd9": {
+      "id": "cross-spawn@7.0.3@d41d8cd9",
+      "name": "cross-spawn",
+      "version": "7.0.3",
+      "source": {
+        "type": "install",
+        "source": [
+          "archive:https://registry.npmjs.org/cross-spawn/-/cross-spawn-7.0.3.tgz#sha1:f73a85b9d5d41d045551c177e2882d4ac85728a6"
+        ]
+      },
+      "overrides": [],
+      "dependencies": [
+        "which@2.0.2@d41d8cd9", "shebang-command@2.0.0@d41d8cd9",
+        "path-key@3.1.1@d41d8cd9"
+      ],
       "devDependencies": []
     },
     "create-hmac@1.1.7@d41d8cd9": {
@@ -915,6 +2071,48 @@
         "type": "install",
         "source": [
           "archive:https://registry.npmjs.org/cookiejar/-/cookiejar-2.1.2.tgz#sha1:dd8a235530752f988f9a0844f3fc589e3111125c"
+        ]
+      },
+      "overrides": [],
+      "dependencies": [],
+      "devDependencies": []
+    },
+    "commander@7.2.0@d41d8cd9": {
+      "id": "commander@7.2.0@d41d8cd9",
+      "name": "commander",
+      "version": "7.2.0",
+      "source": {
+        "type": "install",
+        "source": [
+          "archive:https://registry.npmjs.org/commander/-/commander-7.2.0.tgz#sha1:a36cb57d0b501ce108e4d20559a150a391d97ab7"
+        ]
+      },
+      "overrides": [],
+      "dependencies": [],
+      "devDependencies": []
+    },
+    "commander@2.20.3@d41d8cd9": {
+      "id": "commander@2.20.3@d41d8cd9",
+      "name": "commander",
+      "version": "2.20.3",
+      "source": {
+        "type": "install",
+        "source": [
+          "archive:https://registry.npmjs.org/commander/-/commander-2.20.3.tgz#sha1:fd485e84c03eb4881c20722ba48035e8531aeb33"
+        ]
+      },
+      "overrides": [],
+      "dependencies": [],
+      "devDependencies": []
+    },
+    "colorette@1.2.2@d41d8cd9": {
+      "id": "colorette@1.2.2@d41d8cd9",
+      "name": "colorette",
+      "version": "1.2.2",
+      "source": {
+        "type": "install",
+        "source": [
+          "archive:https://registry.npmjs.org/colorette/-/colorette-1.2.2.tgz#sha1:cbcc79d5e99caea2dbf10eb3a26fd8b3e6acfa94"
         ]
       },
       "overrides": [],
@@ -977,6 +2175,23 @@
       "dependencies": [ "color-name@1.1.3@d41d8cd9" ],
       "devDependencies": []
     },
+    "clone-deep@4.0.1@d41d8cd9": {
+      "id": "clone-deep@4.0.1@d41d8cd9",
+      "name": "clone-deep",
+      "version": "4.0.1",
+      "source": {
+        "type": "install",
+        "source": [
+          "archive:https://registry.npmjs.org/clone-deep/-/clone-deep-4.0.1.tgz#sha1:c19fd9bdbbf85942b4fd979c84dcf7d5f07c2387"
+        ]
+      },
+      "overrides": [],
+      "dependencies": [
+        "shallow-clone@3.0.1@d41d8cd9", "kind-of@6.0.3@d41d8cd9",
+        "is-plain-object@2.0.4@d41d8cd9"
+      ],
+      "devDependencies": []
+    },
     "cipher-base@1.0.4@d41d8cd9": {
       "id": "cipher-base@1.0.4@d41d8cd9",
       "name": "cipher-base",
@@ -991,6 +2206,20 @@
       "dependencies": [
         "safe-buffer@5.2.1@d41d8cd9", "inherits@2.0.4@d41d8cd9"
       ],
+      "devDependencies": []
+    },
+    "chrome-trace-event@1.0.3@d41d8cd9": {
+      "id": "chrome-trace-event@1.0.3@d41d8cd9",
+      "name": "chrome-trace-event",
+      "version": "1.0.3",
+      "source": {
+        "type": "install",
+        "source": [
+          "archive:https://registry.npmjs.org/chrome-trace-event/-/chrome-trace-event-1.0.3.tgz#sha1:1015eced4741e15d06664a957dbbf50d041e26ac"
+        ]
+      },
+      "overrides": [],
+      "dependencies": [],
       "devDependencies": []
     },
     "chalk@4.1.2@d41d8cd9": {
@@ -1024,6 +2253,34 @@
         "supports-color@5.5.0@d41d8cd9",
         "escape-string-regexp@1.0.5@d41d8cd9", "ansi-styles@3.2.1@d41d8cd9"
       ],
+      "devDependencies": []
+    },
+    "caniuse-lite@1.0.30001248@d41d8cd9": {
+      "id": "caniuse-lite@1.0.30001248@d41d8cd9",
+      "name": "caniuse-lite",
+      "version": "1.0.30001248",
+      "source": {
+        "type": "install",
+        "source": [
+          "archive:https://registry.npmjs.org/caniuse-lite/-/caniuse-lite-1.0.30001248.tgz#sha1:26ab45e340f155ea5da2920dadb76a533cb8ebce"
+        ]
+      },
+      "overrides": [],
+      "dependencies": [],
+      "devDependencies": []
+    },
+    "buffer-from@1.1.2@d41d8cd9": {
+      "id": "buffer-from@1.1.2@d41d8cd9",
+      "name": "buffer-from",
+      "version": "1.1.2",
+      "source": {
+        "type": "install",
+        "source": [
+          "archive:https://registry.npmjs.org/buffer-from/-/buffer-from-1.1.2.tgz#sha1:2b146a6fd72e80b4f55d255f35ed59a3a9a41bd5"
+        ]
+      },
+      "overrides": [],
+      "dependencies": [],
       "devDependencies": []
     },
     "buffer@6.0.3@d41d8cd9": {
@@ -1071,6 +2328,24 @@
       },
       "overrides": [],
       "dependencies": [ "base-x@3.0.8@d41d8cd9" ],
+      "devDependencies": []
+    },
+    "browserslist@4.16.6@d41d8cd9": {
+      "id": "browserslist@4.16.6@d41d8cd9",
+      "name": "browserslist",
+      "version": "4.16.6",
+      "source": {
+        "type": "install",
+        "source": [
+          "archive:https://registry.npmjs.org/browserslist/-/browserslist-4.16.6.tgz#sha1:d7901277a5a88e554ed305b183ec9b0c08f66fa2"
+        ]
+      },
+      "overrides": [],
+      "dependencies": [
+        "node-releases@1.1.73@d41d8cd9", "escalade@3.1.1@d41d8cd9",
+        "electron-to-chromium@1.3.792@d41d8cd9", "colorette@1.2.2@d41d8cd9",
+        "caniuse-lite@1.0.30001248@d41d8cd9"
+      ],
       "devDependencies": []
     },
     "brorand@1.1.0@d41d8cd9": {
@@ -1230,6 +2505,377 @@
       "dependencies": [],
       "devDependencies": []
     },
+    "ajv-keywords@3.5.2@d41d8cd9": {
+      "id": "ajv-keywords@3.5.2@d41d8cd9",
+      "name": "ajv-keywords",
+      "version": "3.5.2",
+      "source": {
+        "type": "install",
+        "source": [
+          "archive:https://registry.npmjs.org/ajv-keywords/-/ajv-keywords-3.5.2.tgz#sha1:31f29da5ab6e00d1c2d329acf7b5929614d5014d"
+        ]
+      },
+      "overrides": [],
+      "dependencies": [ "ajv@6.12.6@d41d8cd9" ],
+      "devDependencies": []
+    },
+    "ajv@6.12.6@d41d8cd9": {
+      "id": "ajv@6.12.6@d41d8cd9",
+      "name": "ajv",
+      "version": "6.12.6",
+      "source": {
+        "type": "install",
+        "source": [
+          "archive:https://registry.npmjs.org/ajv/-/ajv-6.12.6.tgz#sha1:baf5a62e802b07d977034586f8c3baf5adf26df4"
+        ]
+      },
+      "overrides": [],
+      "dependencies": [
+        "uri-js@4.4.1@d41d8cd9", "json-schema-traverse@0.4.1@d41d8cd9",
+        "fast-json-stable-stringify@2.1.0@d41d8cd9",
+        "fast-deep-equal@3.1.3@d41d8cd9"
+      ],
+      "devDependencies": []
+    },
+    "acorn@8.4.1@d41d8cd9": {
+      "id": "acorn@8.4.1@d41d8cd9",
+      "name": "acorn",
+      "version": "8.4.1",
+      "source": {
+        "type": "install",
+        "source": [
+          "archive:https://registry.npmjs.org/acorn/-/acorn-8.4.1.tgz#sha1:56c36251fc7cabc7096adc18f05afe814321a28c"
+        ]
+      },
+      "overrides": [],
+      "dependencies": [],
+      "devDependencies": []
+    },
+    "@xtuc/long@4.2.2@d41d8cd9": {
+      "id": "@xtuc/long@4.2.2@d41d8cd9",
+      "name": "@xtuc/long",
+      "version": "4.2.2",
+      "source": {
+        "type": "install",
+        "source": [
+          "archive:https://registry.npmjs.org/@xtuc/long/-/long-4.2.2.tgz#sha1:d291c6a4e97989b5c61d9acf396ae4fe133a718d"
+        ]
+      },
+      "overrides": [],
+      "dependencies": [],
+      "devDependencies": []
+    },
+    "@xtuc/ieee754@1.2.0@d41d8cd9": {
+      "id": "@xtuc/ieee754@1.2.0@d41d8cd9",
+      "name": "@xtuc/ieee754",
+      "version": "1.2.0",
+      "source": {
+        "type": "install",
+        "source": [
+          "archive:https://registry.npmjs.org/@xtuc/ieee754/-/ieee754-1.2.0.tgz#sha1:eef014a3145ae477a1cbc00cd1e552336dceb790"
+        ]
+      },
+      "overrides": [],
+      "dependencies": [],
+      "devDependencies": []
+    },
+    "@webpack-cli/serve@1.5.1@d41d8cd9": {
+      "id": "@webpack-cli/serve@1.5.1@d41d8cd9",
+      "name": "@webpack-cli/serve",
+      "version": "1.5.1",
+      "source": {
+        "type": "install",
+        "source": [
+          "archive:https://registry.npmjs.org/@webpack-cli/serve/-/serve-1.5.1.tgz#sha1:b5fde2f0f79c1e120307c415a4c1d5eb15a6f278"
+        ]
+      },
+      "overrides": [],
+      "dependencies": [ "webpack-cli@4.7.2@d41d8cd9" ],
+      "devDependencies": []
+    },
+    "@webpack-cli/info@1.3.0@d41d8cd9": {
+      "id": "@webpack-cli/info@1.3.0@d41d8cd9",
+      "name": "@webpack-cli/info",
+      "version": "1.3.0",
+      "source": {
+        "type": "install",
+        "source": [
+          "archive:https://registry.npmjs.org/@webpack-cli/info/-/info-1.3.0.tgz#sha1:9d78a31101a960997a4acd41ffd9b9300627fe2b"
+        ]
+      },
+      "overrides": [],
+      "dependencies": [
+        "webpack-cli@4.7.2@d41d8cd9", "envinfo@7.8.1@d41d8cd9"
+      ],
+      "devDependencies": []
+    },
+    "@webpack-cli/configtest@1.0.4@d41d8cd9": {
+      "id": "@webpack-cli/configtest@1.0.4@d41d8cd9",
+      "name": "@webpack-cli/configtest",
+      "version": "1.0.4",
+      "source": {
+        "type": "install",
+        "source": [
+          "archive:https://registry.npmjs.org/@webpack-cli/configtest/-/configtest-1.0.4.tgz#sha1:f03ce6311c0883a83d04569e2c03c6238316d2aa"
+        ]
+      },
+      "overrides": [],
+      "dependencies": [
+        "webpack-cli@4.7.2@d41d8cd9", "webpack@5.47.1@d41d8cd9"
+      ],
+      "devDependencies": []
+    },
+    "@webassemblyjs/wast-printer@1.11.1@d41d8cd9": {
+      "id": "@webassemblyjs/wast-printer@1.11.1@d41d8cd9",
+      "name": "@webassemblyjs/wast-printer",
+      "version": "1.11.1",
+      "source": {
+        "type": "install",
+        "source": [
+          "archive:https://registry.npmjs.org/@webassemblyjs/wast-printer/-/wast-printer-1.11.1.tgz#sha1:d0c73beda8eec5426f10ae8ef55cee5e7084c2f0"
+        ]
+      },
+      "overrides": [],
+      "dependencies": [
+        "@xtuc/long@4.2.2@d41d8cd9", "@webassemblyjs/ast@1.11.1@d41d8cd9"
+      ],
+      "devDependencies": []
+    },
+    "@webassemblyjs/wasm-parser@1.11.1@d41d8cd9": {
+      "id": "@webassemblyjs/wasm-parser@1.11.1@d41d8cd9",
+      "name": "@webassemblyjs/wasm-parser",
+      "version": "1.11.1",
+      "source": {
+        "type": "install",
+        "source": [
+          "archive:https://registry.npmjs.org/@webassemblyjs/wasm-parser/-/wasm-parser-1.11.1.tgz#sha1:86ca734534f417e9bd3c67c7a1c75d8be41fb199"
+        ]
+      },
+      "overrides": [],
+      "dependencies": [
+        "@webassemblyjs/utf8@1.11.1@d41d8cd9",
+        "@webassemblyjs/leb128@1.11.1@d41d8cd9",
+        "@webassemblyjs/ieee754@1.11.1@d41d8cd9",
+        "@webassemblyjs/helper-wasm-bytecode@1.11.1@d41d8cd9",
+        "@webassemblyjs/helper-api-error@1.11.1@d41d8cd9",
+        "@webassemblyjs/ast@1.11.1@d41d8cd9"
+      ],
+      "devDependencies": []
+    },
+    "@webassemblyjs/wasm-opt@1.11.1@d41d8cd9": {
+      "id": "@webassemblyjs/wasm-opt@1.11.1@d41d8cd9",
+      "name": "@webassemblyjs/wasm-opt",
+      "version": "1.11.1",
+      "source": {
+        "type": "install",
+        "source": [
+          "archive:https://registry.npmjs.org/@webassemblyjs/wasm-opt/-/wasm-opt-1.11.1.tgz#sha1:657b4c2202f4cf3b345f8a4c6461c8c2418985f2"
+        ]
+      },
+      "overrides": [],
+      "dependencies": [
+        "@webassemblyjs/wasm-parser@1.11.1@d41d8cd9",
+        "@webassemblyjs/wasm-gen@1.11.1@d41d8cd9",
+        "@webassemblyjs/helper-buffer@1.11.1@d41d8cd9",
+        "@webassemblyjs/ast@1.11.1@d41d8cd9"
+      ],
+      "devDependencies": []
+    },
+    "@webassemblyjs/wasm-gen@1.11.1@d41d8cd9": {
+      "id": "@webassemblyjs/wasm-gen@1.11.1@d41d8cd9",
+      "name": "@webassemblyjs/wasm-gen",
+      "version": "1.11.1",
+      "source": {
+        "type": "install",
+        "source": [
+          "archive:https://registry.npmjs.org/@webassemblyjs/wasm-gen/-/wasm-gen-1.11.1.tgz#sha1:86c5ea304849759b7d88c47a32f4f039ae3c8f76"
+        ]
+      },
+      "overrides": [],
+      "dependencies": [
+        "@webassemblyjs/utf8@1.11.1@d41d8cd9",
+        "@webassemblyjs/leb128@1.11.1@d41d8cd9",
+        "@webassemblyjs/ieee754@1.11.1@d41d8cd9",
+        "@webassemblyjs/helper-wasm-bytecode@1.11.1@d41d8cd9",
+        "@webassemblyjs/ast@1.11.1@d41d8cd9"
+      ],
+      "devDependencies": []
+    },
+    "@webassemblyjs/wasm-edit@1.11.1@d41d8cd9": {
+      "id": "@webassemblyjs/wasm-edit@1.11.1@d41d8cd9",
+      "name": "@webassemblyjs/wasm-edit",
+      "version": "1.11.1",
+      "source": {
+        "type": "install",
+        "source": [
+          "archive:https://registry.npmjs.org/@webassemblyjs/wasm-edit/-/wasm-edit-1.11.1.tgz#sha1:ad206ebf4bf95a058ce9880a8c092c5dec8193d6"
+        ]
+      },
+      "overrides": [],
+      "dependencies": [
+        "@webassemblyjs/wast-printer@1.11.1@d41d8cd9",
+        "@webassemblyjs/wasm-parser@1.11.1@d41d8cd9",
+        "@webassemblyjs/wasm-opt@1.11.1@d41d8cd9",
+        "@webassemblyjs/wasm-gen@1.11.1@d41d8cd9",
+        "@webassemblyjs/helper-wasm-section@1.11.1@d41d8cd9",
+        "@webassemblyjs/helper-wasm-bytecode@1.11.1@d41d8cd9",
+        "@webassemblyjs/helper-buffer@1.11.1@d41d8cd9",
+        "@webassemblyjs/ast@1.11.1@d41d8cd9"
+      ],
+      "devDependencies": []
+    },
+    "@webassemblyjs/utf8@1.11.1@d41d8cd9": {
+      "id": "@webassemblyjs/utf8@1.11.1@d41d8cd9",
+      "name": "@webassemblyjs/utf8",
+      "version": "1.11.1",
+      "source": {
+        "type": "install",
+        "source": [
+          "archive:https://registry.npmjs.org/@webassemblyjs/utf8/-/utf8-1.11.1.tgz#sha1:d1f8b764369e7c6e6bae350e854dec9a59f0a3ff"
+        ]
+      },
+      "overrides": [],
+      "dependencies": [],
+      "devDependencies": []
+    },
+    "@webassemblyjs/leb128@1.11.1@d41d8cd9": {
+      "id": "@webassemblyjs/leb128@1.11.1@d41d8cd9",
+      "name": "@webassemblyjs/leb128",
+      "version": "1.11.1",
+      "source": {
+        "type": "install",
+        "source": [
+          "archive:https://registry.npmjs.org/@webassemblyjs/leb128/-/leb128-1.11.1.tgz#sha1:ce814b45574e93d76bae1fb2644ab9cdd9527aa5"
+        ]
+      },
+      "overrides": [],
+      "dependencies": [ "@xtuc/long@4.2.2@d41d8cd9" ],
+      "devDependencies": []
+    },
+    "@webassemblyjs/ieee754@1.11.1@d41d8cd9": {
+      "id": "@webassemblyjs/ieee754@1.11.1@d41d8cd9",
+      "name": "@webassemblyjs/ieee754",
+      "version": "1.11.1",
+      "source": {
+        "type": "install",
+        "source": [
+          "archive:https://registry.npmjs.org/@webassemblyjs/ieee754/-/ieee754-1.11.1.tgz#sha1:963929e9bbd05709e7e12243a099180812992614"
+        ]
+      },
+      "overrides": [],
+      "dependencies": [ "@xtuc/ieee754@1.2.0@d41d8cd9" ],
+      "devDependencies": []
+    },
+    "@webassemblyjs/helper-wasm-section@1.11.1@d41d8cd9": {
+      "id": "@webassemblyjs/helper-wasm-section@1.11.1@d41d8cd9",
+      "name": "@webassemblyjs/helper-wasm-section",
+      "version": "1.11.1",
+      "source": {
+        "type": "install",
+        "source": [
+          "archive:https://registry.npmjs.org/@webassemblyjs/helper-wasm-section/-/helper-wasm-section-1.11.1.tgz#sha1:21ee065a7b635f319e738f0dd73bfbda281c097a"
+        ]
+      },
+      "overrides": [],
+      "dependencies": [
+        "@webassemblyjs/wasm-gen@1.11.1@d41d8cd9",
+        "@webassemblyjs/helper-wasm-bytecode@1.11.1@d41d8cd9",
+        "@webassemblyjs/helper-buffer@1.11.1@d41d8cd9",
+        "@webassemblyjs/ast@1.11.1@d41d8cd9"
+      ],
+      "devDependencies": []
+    },
+    "@webassemblyjs/helper-wasm-bytecode@1.11.1@d41d8cd9": {
+      "id": "@webassemblyjs/helper-wasm-bytecode@1.11.1@d41d8cd9",
+      "name": "@webassemblyjs/helper-wasm-bytecode",
+      "version": "1.11.1",
+      "source": {
+        "type": "install",
+        "source": [
+          "archive:https://registry.npmjs.org/@webassemblyjs/helper-wasm-bytecode/-/helper-wasm-bytecode-1.11.1.tgz#sha1:f328241e41e7b199d0b20c18e88429c4433295e1"
+        ]
+      },
+      "overrides": [],
+      "dependencies": [],
+      "devDependencies": []
+    },
+    "@webassemblyjs/helper-numbers@1.11.1@d41d8cd9": {
+      "id": "@webassemblyjs/helper-numbers@1.11.1@d41d8cd9",
+      "name": "@webassemblyjs/helper-numbers",
+      "version": "1.11.1",
+      "source": {
+        "type": "install",
+        "source": [
+          "archive:https://registry.npmjs.org/@webassemblyjs/helper-numbers/-/helper-numbers-1.11.1.tgz#sha1:64d81da219fbbba1e3bd1bfc74f6e8c4e10a62ae"
+        ]
+      },
+      "overrides": [],
+      "dependencies": [
+        "@xtuc/long@4.2.2@d41d8cd9",
+        "@webassemblyjs/helper-api-error@1.11.1@d41d8cd9",
+        "@webassemblyjs/floating-point-hex-parser@1.11.1@d41d8cd9"
+      ],
+      "devDependencies": []
+    },
+    "@webassemblyjs/helper-buffer@1.11.1@d41d8cd9": {
+      "id": "@webassemblyjs/helper-buffer@1.11.1@d41d8cd9",
+      "name": "@webassemblyjs/helper-buffer",
+      "version": "1.11.1",
+      "source": {
+        "type": "install",
+        "source": [
+          "archive:https://registry.npmjs.org/@webassemblyjs/helper-buffer/-/helper-buffer-1.11.1.tgz#sha1:832a900eb444884cde9a7cad467f81500f5e5ab5"
+        ]
+      },
+      "overrides": [],
+      "dependencies": [],
+      "devDependencies": []
+    },
+    "@webassemblyjs/helper-api-error@1.11.1@d41d8cd9": {
+      "id": "@webassemblyjs/helper-api-error@1.11.1@d41d8cd9",
+      "name": "@webassemblyjs/helper-api-error",
+      "version": "1.11.1",
+      "source": {
+        "type": "install",
+        "source": [
+          "archive:https://registry.npmjs.org/@webassemblyjs/helper-api-error/-/helper-api-error-1.11.1.tgz#sha1:1a63192d8788e5c012800ba6a7a46c705288fd16"
+        ]
+      },
+      "overrides": [],
+      "dependencies": [],
+      "devDependencies": []
+    },
+    "@webassemblyjs/floating-point-hex-parser@1.11.1@d41d8cd9": {
+      "id": "@webassemblyjs/floating-point-hex-parser@1.11.1@d41d8cd9",
+      "name": "@webassemblyjs/floating-point-hex-parser",
+      "version": "1.11.1",
+      "source": {
+        "type": "install",
+        "source": [
+          "archive:https://registry.npmjs.org/@webassemblyjs/floating-point-hex-parser/-/floating-point-hex-parser-1.11.1.tgz#sha1:f6c61a705f0fd7a6aecaa4e8198f23d9dc179e4f"
+        ]
+      },
+      "overrides": [],
+      "dependencies": [],
+      "devDependencies": []
+    },
+    "@webassemblyjs/ast@1.11.1@d41d8cd9": {
+      "id": "@webassemblyjs/ast@1.11.1@d41d8cd9",
+      "name": "@webassemblyjs/ast",
+      "version": "1.11.1",
+      "source": {
+        "type": "install",
+        "source": [
+          "archive:https://registry.npmjs.org/@webassemblyjs/ast/-/ast-1.11.1.tgz#sha1:2bfd767eae1a6996f432ff7e8d7fc75679c0b6a7"
+        ]
+      },
+      "overrides": [],
+      "dependencies": [
+        "@webassemblyjs/helper-wasm-bytecode@1.11.1@d41d8cd9",
+        "@webassemblyjs/helper-numbers@1.11.1@d41d8cd9"
+      ],
+      "devDependencies": []
+    },
     "@types/yargs-parser@20.2.1@d41d8cd9": {
       "id": "@types/yargs-parser@20.2.1@d41d8cd9",
       "name": "@types/yargs-parser",
@@ -1286,6 +2932,20 @@
       "dependencies": [],
       "devDependencies": []
     },
+    "@types/json-schema@7.0.8@d41d8cd9": {
+      "id": "@types/json-schema@7.0.8@d41d8cd9",
+      "name": "@types/json-schema",
+      "version": "7.0.8",
+      "source": {
+        "type": "install",
+        "source": [
+          "archive:https://registry.npmjs.org/@types/json-schema/-/json-schema-7.0.8.tgz#sha1:edf1bf1dbf4e04413ca8e5b17b3b7d7d54b59818"
+        ]
+      },
+      "overrides": [],
+      "dependencies": [],
+      "devDependencies": []
+    },
     "@types/istanbul-reports@3.0.1@d41d8cd9": {
       "id": "@types/istanbul-reports@3.0.1@d41d8cd9",
       "name": "@types/istanbul-reports",
@@ -1326,6 +2986,52 @@
       },
       "overrides": [],
       "dependencies": [],
+      "devDependencies": []
+    },
+    "@types/estree@0.0.50@d41d8cd9": {
+      "id": "@types/estree@0.0.50@d41d8cd9",
+      "name": "@types/estree",
+      "version": "0.0.50",
+      "source": {
+        "type": "install",
+        "source": [
+          "archive:https://registry.npmjs.org/@types/estree/-/estree-0.0.50.tgz#sha1:1e0caa9364d3fccd2931c3ed96fdbeaa5d4cca83"
+        ]
+      },
+      "overrides": [],
+      "dependencies": [],
+      "devDependencies": []
+    },
+    "@types/eslint-scope@3.7.1@d41d8cd9": {
+      "id": "@types/eslint-scope@3.7.1@d41d8cd9",
+      "name": "@types/eslint-scope",
+      "version": "3.7.1",
+      "source": {
+        "type": "install",
+        "source": [
+          "archive:https://registry.npmjs.org/@types/eslint-scope/-/eslint-scope-3.7.1.tgz#sha1:8dc390a7b4f9dd9f1284629efce982e41612116e"
+        ]
+      },
+      "overrides": [],
+      "dependencies": [
+        "@types/estree@0.0.50@d41d8cd9", "@types/eslint@7.28.0@d41d8cd9"
+      ],
+      "devDependencies": []
+    },
+    "@types/eslint@7.28.0@d41d8cd9": {
+      "id": "@types/eslint@7.28.0@d41d8cd9",
+      "name": "@types/eslint",
+      "version": "7.28.0",
+      "source": {
+        "type": "install",
+        "source": [
+          "archive:https://registry.npmjs.org/@types/eslint/-/eslint-7.28.0.tgz#sha1:7e41f2481d301c68e14f483fe10b017753ce8d5a"
+        ]
+      },
+      "overrides": [],
+      "dependencies": [
+        "@types/json-schema@7.0.8@d41d8cd9", "@types/estree@0.0.50@d41d8cd9"
+      ],
       "devDependencies": []
     },
     "@taquito/utils@9.2.0@d41d8cd9": {
@@ -5278,6 +6984,20 @@
       ],
       "devDependencies": []
     },
+    "@discoveryjs/json-ext@0.5.3@d41d8cd9": {
+      "id": "@discoveryjs/json-ext@0.5.3@d41d8cd9",
+      "name": "@discoveryjs/json-ext",
+      "version": "0.5.3",
+      "source": {
+        "type": "install",
+        "source": [
+          "archive:https://registry.npmjs.org/@discoveryjs/json-ext/-/json-ext-0.5.3.tgz#sha1:90420f9f9c6d3987f176a19a7d8e764271a2f55d"
+        ]
+      },
+      "overrides": [],
+      "dependencies": [],
+      "devDependencies": []
+    },
     "@babel/highlight@7.14.5@d41d8cd9": {
       "id": "@babel/highlight@7.14.5@d41d8cd9",
       "name": "@babel/highlight",
@@ -5291,18 +7011,18 @@
       "overrides": [],
       "dependencies": [
         "js-tokens@4.0.0@d41d8cd9", "chalk@2.4.2@d41d8cd9",
-        "@babel/helper-validator-identifier@7.14.8@d41d8cd9"
+        "@babel/helper-validator-identifier@7.14.9@d41d8cd9"
       ],
       "devDependencies": []
     },
-    "@babel/helper-validator-identifier@7.14.8@d41d8cd9": {
-      "id": "@babel/helper-validator-identifier@7.14.8@d41d8cd9",
+    "@babel/helper-validator-identifier@7.14.9@d41d8cd9": {
+      "id": "@babel/helper-validator-identifier@7.14.9@d41d8cd9",
       "name": "@babel/helper-validator-identifier",
-      "version": "7.14.8",
+      "version": "7.14.9",
       "source": {
         "type": "install",
         "source": [
-          "archive:https://registry.npmjs.org/@babel/helper-validator-identifier/-/helper-validator-identifier-7.14.8.tgz#sha1:32be33a756f29e278a0d644fa08a2c9e0f88a34c"
+          "archive:https://registry.npmjs.org/@babel/helper-validator-identifier/-/helper-validator-identifier-7.14.9.tgz#sha1:6654d171b2024f6d8ee151bf2509699919131d48"
         ]
       },
       "overrides": [],

--- a/esy.lock/opam/ppx_blob.0.7.2/opam
+++ b/esy.lock/opam/ppx_blob.0.7.2/opam
@@ -1,0 +1,29 @@
+opam-version: "2.0"
+authors: "John Whitington"
+maintainer: "contact@coherentgraphics.co.uk"
+homepage: "https://github.com/johnwhitington/ppx_blob"
+dev-repo: "git+https://github.com/johnwhitington/ppx_blob.git"
+bug-reports: "https://github.com/johnwhitington/ppx_blob/issues/"
+doc: "https://johnwhitington.github.io/ppx_blob/"
+build: [
+  ["dune" "build" "-p" name "-j" jobs]
+  ["dune" "runtest" "-p" name "-j" jobs] {with-test}
+]
+depends: [
+  "ocaml"
+  "dune"
+  "ppxlib"
+  "alcotest" {with-test}
+]
+synopsis: "Include a file as a string at compile time"
+description:
+  "ppx_blob allows you to include a binary blob from a file as a string. Writing `[%blob \"filename\"]` will replace the string with the contents of the file at compile time. This allows the inclusion of arbitary, possibly compressed, data, without the need to respect OCaml's lexical conventions."
+x-commit-hash: "3118ced54a0f4c94dcc51892ccffdd836ac4cbef"
+url {
+  src:
+    "https://github.com/johnwhitington/ppx_blob/releases/download/0.7.2/ppx_blob-0.7.2.tbz"
+  checksum: [
+    "sha256=bcb9dcab18a3b40b5d6d9656575001c6379abf29461aa87d9263d25b59f80a02"
+    "sha512=d1701f640ce3dda2e2f0dce7d3f4a6b33ddfdaf793a9beab73e4f9ac93b2912adb7bb3b7fd1800bab258302aef0f0cdefb1e20ee62e6d882b25f0a64eae390a3"
+  ]
+}

--- a/package.json
+++ b/package.json
@@ -7,6 +7,9 @@
         "genesis_helper",
         "sidecli"
       ]
+    },
+    "buildEnv": {
+      "PATH": "%{localStore}%/../bin:$PATH"
     }
   },
   "license": "MIT",

--- a/package.json
+++ b/package.json
@@ -35,7 +35,8 @@
     "@taquito/taquito": "^9.0.1",
     "@taquito/signer": "^9.0.1",
     "webpack": "^5.47.1",
-    "webpack-cli": "^4.7.1"
+    "webpack-cli": "^4.7.1",
+    "@opam/ppx_blob": "*"
   },
   "devDependencies": {
     "@opam/ocaml-lsp-server": "*",

--- a/package.json
+++ b/package.json
@@ -33,7 +33,9 @@
     "@opam/digestif": "*",
     "@opam/cmdliner": "1.0.4",
     "@taquito/taquito": "^9.0.1",
-    "@taquito/signer": "^9.0.1"
+    "@taquito/signer": "^9.0.1",
+    "webpack": "^5.47.1",
+    "webpack-cli": "^4.7.1"
   },
   "devDependencies": {
     "@opam/ocaml-lsp-server": "*",

--- a/tezos_interop/dune
+++ b/tezos_interop/dune
@@ -2,4 +2,13 @@
  (name tezos_interop)
  (libraries helpers lwt.unix mirage-crypto-ec tezos-micheline)
  (preprocess
-  (pps ppx_deriving_yojson)))
+  (pps ppx_deriving_yojson ppx_blob))
+ (preprocessor_deps
+  (file ./run_entrypoint.bundle.js)))
+
+(rule
+ (deps ./webpack.config.js ./run_entrypoint.js)
+ (targets ./run_entrypoint.bundle.js)
+ (mode fallback)
+ (action
+  (run webpack --env=%{profile})))

--- a/tezos_interop/tezos_interop.re
+++ b/tezos_interop/tezos_interop.re
@@ -439,6 +439,7 @@ module Run_contract = {
   };
 
   // TODO: probably we should add a ppx to load this file in the bundle
+  let _ = [%blob "run_entrypoint.bundle.js"];
   let file = Sys.executable_name ++ "/../tezos_interop/run_entrypoint.js";
   let run = (~context, ~destination, ~entrypoint, ~payload) => {
     let input = {

--- a/tezos_interop/tezos_interop.re
+++ b/tezos_interop/tezos_interop.re
@@ -438,9 +438,13 @@ module Run_contract = {
     };
   };
 
-  // TODO: probably we should add a ppx to load this file in the bundle
-  let _ = [%blob "run_entrypoint.bundle.js"];
-  let file = Sys.executable_name ++ "/../tezos_interop/run_entrypoint.js";
+  // TODO: this leaks the file as it needs to be removed when the app closes
+  let file = {
+    let.await (file, oc) = Lwt_io.open_temp_file(~suffix=".js", ());
+    let.await () = Lwt_io.write(oc, [%blob "run_entrypoint.bundle.js"]);
+    await(file);
+  };
+  let file = Lwt_main.run(file);
   let run = (~context, ~destination, ~entrypoint, ~payload) => {
     let input = {
       rpc_node: context.Context.rpc_node |> Uri.to_string,
@@ -547,7 +551,7 @@ module Consensus = {
       Run_contract.run(
         ~context,
         ~destination=context.Context.consensus_contract,
-        ~entrypoint="default",
+        ~entrypoint="update_root_hash",
         ~payload=Payload.to_yojson(payload),
       );
     await();

--- a/tezos_interop/webpack.config.js
+++ b/tezos_interop/webpack.config.js
@@ -1,0 +1,9 @@
+module.exports = env => ({
+  entry: ['./run_entrypoint.js'],
+  output: {
+    filename: 'run_entrypoint.bundle.js',
+    path: __dirname,
+  },
+  mode: env.dev ? 'development' : 'production',
+  target: 'node'
+});


### PR DESCRIPTION
## Problem

Since #105 we use a JS script to commit the sidechain state hash to Tezos, this is a problem as to run this script we need not only `node` but also `esy` which all the dependencies installed locally.

## Solution

This uses webpack to generate a standalone bundle and ppx_blob to inline the JS file in the binary, and during runtime the binary creates a temporary file with JS which will be used during the lifetime of the node.

With this you only need `node` available on the environment which is a much smaller requirement.

## **Warning**

This requires you to update your esy to the latest nightly as esy had a problem related to JS packages inside of the `_esy`.