### PR TITLE
fix signatures on commit state hash

### DIFF
--- a/node/state.re
+++ b/node/state.re
@@ -64,7 +64,7 @@ let try_to_commit_state_hash = (~old_state, state, block, signatures) => {
   let signatures_map =
     signatures
     |> Signatures.to_list
-    |> List.map(Signature.signature_to_b58check_by_address)
+    |> List.map(Signature.signature_to_tezos_signature_by_address)
     |> List.to_seq
     |> Address_map.of_seq;
 
@@ -81,10 +81,7 @@ let try_to_commit_state_hash = (~old_state, state, block, signatures) => {
     |> List.map(address =>
          (
            Tezos_interop.Key.Ed25519(address),
-           Address_map.find_opt(address, signatures_map)
-           |> Option.map(signature =>
-                Tezos_interop.Signature.of_raw_string(`Ed25519(signature))
-              ),
+           Address_map.find_opt(address, signatures_map),
          )
        );
 

--- a/protocol/signature.re
+++ b/protocol/signature.re
@@ -30,6 +30,10 @@ let signature_to_b58check = t => {
 let signature_to_b58check_by_address = t => {
   (t.public_key, signature_to_b58check(t));
 };
+let signature_to_tezos_signature_by_address = t => (
+  t.public_key,
+  Tezos_interop.Signature.of_raw_string(`Ed25519(t.signature)),
+);
 let verify = (~signature, hash) => {
   let hash = BLAKE2B.to_raw_string(hash) |> BLAKE2B.hash;
   Ed25519.verify(

--- a/protocol/signature.rei
+++ b/protocol/signature.rei
@@ -11,6 +11,9 @@ let verify: (~signature: t, BLAKE2B.t) => bool;
 
 let signature_to_b58check: t => string;
 let signature_to_b58check_by_address: t => (Address.t, string);
+let signature_to_tezos_signature_by_address:
+  t => (Address.t, Tezos_interop.Signature.t);
+
 module type S = {
   type value;
   type signature = t;


### PR DESCRIPTION
## Problem

On #100 we added a function to commit the state hash automatically from the node and on #105 it was integrated, because this function was not properly tested it contained a bug on the signatures where the signature was actually a b58(b58(sign)) instead of b58(sign).

## Solution

This PR fixes it and also move this abstraction to the Signature module, so that in the future it is properly tested.

## Related

- #34 
- #61 