### PR TITLE
log global async exceptions

### DIFF
--- a/node/flows.re
+++ b/node/flows.re
@@ -118,8 +118,9 @@ let rec request_protocol_snapshot = tries => {
 };
 Lwt.async_exception_hook :=
   (
-    _exn => {
-      print_endline("global exception");
+    exn => {
+      Printexc.to_string(exn) |> Format.eprintf("global_exception: %s\n%!");
+      Printexc.print_backtrace(stderr);
     }
   );
 let pending = ref(false);


### PR DESCRIPTION
## Problem

Currently when an async global exceptions happens we only have `global exceptions` as an error message, which doesn't tell us anything about the error.

## Solution

Properly print the error message to stderr and try to print the backtrace.