### PR TITLE
print block hash on produce-block

### DIFF
--- a/bin/sidecli.re
+++ b/bin/sidecli.re
@@ -301,6 +301,7 @@ let produce_block = (wallet_file, state_bin) => {
         {block, signature},
       )
     );
+  Format.printf("block.hash: %s\n%!", BLAKE2B.to_string(block.hash));
   Lwt.return(`Ok());
 };
 


### PR DESCRIPTION
## Problem

`produce-block` should be used to unstale a side chain by producing a block then sharing the hash and manually signing the block with `sign-block` but currently that's not possible as it doesn't return the hash .

## Solution

This makes so that produce-block will print to the stdout something like `block.hash: HASH` which can be used together with `awk` to automate and replace `inject-genesis` but also to unstale the chain in a proper way.