### PR TITLE
fix run_entrypoint

### DIFF
--- a/tezos_interop/run_entrypoint.js
+++ b/tezos_interop/run_entrypoint.js
@@ -48,7 +48,7 @@ const error = (error) =>
   Tezos.setProvider({ signer });
 
   const contract = await Tezos.contract.at(destination);
-  const operation = await contract.methods[entrypoint](args).send();
+  const operation = await contract.methods[entrypoint](...args).send();
   await operation.confirmation(confirmation);
 
   finished(operation.status, operation.hash);


### PR DESCRIPTION
## Problem

`run_entrypoint` has a bug where it will submit the argument array as a single element an array, instead of spreading the arguments. 

## Related

- #34 
- #61 