### PR TITLE
Tmuxinator: Build before starting tmux

### DIFF
--- a/.tmuxinator.yml
+++ b/.tmuxinator.yml
@@ -11,7 +11,7 @@ root: ./data
 
 # Project hooks
 # Runs on project start, always
-# on_project_start: command
+on_project_start: esy build
 # Run on project start, the first time
 # on_project_first_start: command
 # Run on project start, after the first time


### PR DESCRIPTION
# Problem

If you make a change, `esy x <command>` rebuilds before executing the command, which messes up the timing (the nodes must start before inject-genesis runs, for example). 

# Solutions

This adds a line in the `.tmuxinator.yml` that builds the project before opening tmux, so everything is always built and the timings are right.