### PR TITLE
support entrypoint on KT1

### DIFF
--- a/tests/test_ledger.re
+++ b/tests/test_ledger.re
@@ -12,13 +12,15 @@ describe("ledger", ({test, _}) => {
       |> Cstruct.to_string
       |> BLAKE2B_20.of_raw_string
       |> Option.get;
-    let ticketer = Address.Originated(random_hash);
     let data =
       switch (data) {
       | Some(data) => data
       | None => Mirage_crypto_rng.generate(256) |> Cstruct.to_bytes
       };
-    Ticket.{ticketer, data};
+    Ticket.{
+      ticketer: Originated({contract: random_hash, entrypoint: None}),
+      data,
+    };
   };
   let make_wallet = () => {
     open Mirage_crypto_ec;

--- a/tests/test_protocol.re
+++ b/tests/test_protocol.re
@@ -5,10 +5,15 @@ open Protocol;
 describe("protocol state", ({test, _}) => {
   let ticket = {
     open Tezos_interop;
-    let key_hash =
-      Key_hash.of_key(Key.Ed25519(Protocol.Address.genesis_address));
-    let ticketer = Address.Implicit(key_hash);
-    Ticket.{ticketer, data: Bytes.of_string("")};
+    let random_hash =
+      Mirage_crypto_rng.generate(20)
+      |> Cstruct.to_string
+      |> Helpers.BLAKE2B_20.of_raw_string
+      |> Option.get;
+    Ticket.{
+      ticketer: Originated({contract: random_hash, entrypoint: None}),
+      data: Bytes.of_string(""),
+    };
   };
   let make_state = (~validators=?, ()) => {
     let (key_wallet, wallet) = Wallet.make_wallet();

--- a/tests/test_tezos_interop.re
+++ b/tests/test_tezos_interop.re
@@ -214,13 +214,18 @@ describe("address", ({test, _}) => {
   open Address;
 
   let tz1 = Implicit(Key_hash.of_key(Ed25519(genesis_address)));
-  let kt1 = Originated(some_contract_hash);
+  let kt1 = Originated({contract: some_contract_hash, entrypoint: None});
+  let kt1_tuturu =
+    Originated({contract: some_contract_hash, entrypoint: Some("tuturu")});
   test("to_string", ({expect, _}) => {
     expect.string(to_string(tz1)).toEqual(
       "tz1LzCSmZHG3jDvqxA8SG8WqbrJ9wz5eUCLC",
     );
     expect.string(to_string(kt1)).toEqual(
       "KT1Dbav7SYrJFpd3bT7sVFDS9MPp4F5gABTc",
+    );
+    expect.string(to_string(kt1_tuturu)).toEqual(
+      "KT1Dbav7SYrJFpd3bT7sVFDS9MPp4F5gABTc%tuturu",
     );
   });
   test("of_string", ({expect, _}) => {
@@ -229,11 +234,26 @@ describe("address", ({test, _}) => {
       ~equals=(==),
       Some(tz1),
     );
+    // TODO: should we accept tz1 with entrypoint?
+    // expect.option(of_string("tz1LzCSmZHG3jDvqxA8SG8WqbrJ9wz5eUCLC%tuturu")).
+    //   toBe(
+    //   // TODO: proper equals
+    //   ~equals=(==),
+    //   Some(tz1),
+    // );
     expect.option(of_string("KT1Dbav7SYrJFpd3bT7sVFDS9MPp4F5gABTc")).toBe(
       // TODO: proper equals
       ~equals=(==),
       Some(kt1),
     );
+    expect.option(of_string("KT1Dbav7SYrJFpd3bT7sVFDS9MPp4F5gABTc%tuturu")).
+      toBe(
+      // TODO: proper equals
+      ~equals=(==),
+      Some(kt1_tuturu),
+    );
+    expect.option(of_string("KT1Dbav7SYrJFpd3bT7sVFDS9MPp4F5gABTc%default")).
+      toBeNone();
   });
   test("invalid prefix", ({expect, _}) => {
     expect.option(of_string("tz4LzCSmZHG3jDvqxA8SG8WqbrJ9wz5eUCLC")).toBeNone()
@@ -248,7 +268,8 @@ describe("address", ({test, _}) => {
 describe("ticket", ({test, _}) => {
   open Ticket;
 
-  let kt1 = Address.Originated(some_contract_hash);
+  let kt1 =
+    Address.Originated({contract: some_contract_hash, entrypoint: None});
   let ticket = {ticketer: kt1, data: Bytes.of_string("a")};
   test("to_string", ({expect, _}) => {
     expect.string(to_string(ticket)).toEqual(
@@ -329,7 +350,7 @@ describe("pack", ({test, _}) => {
   );
   test(
     "address(\"KT1Dbav7SYrJFpd3bT7sVFDS9MPp4F5gABTc\")",
-    address(Originated(some_contract_hash)),
+    address(Originated({contract: some_contract_hash, entrypoint: None})),
     "050a0000001601370027c6c8f3fbafda4f9bfd08b14f45e6a29ce300",
   );
 });

--- a/tezos_interop/tezos_interop.re
+++ b/tezos_interop/tezos_interop.re
@@ -210,13 +210,16 @@ module Contract_hash = {
   let to_string = t => Base58.simple_encode(~prefix, ~to_raw, t);
   let of_string = string => Base58.simple_decode(~prefix, ~of_raw, string);
 };
+
 module Address = {
-  // TODO: there is also contract_hash with entrypoint
   type t =
     | Implicit(Key_hash.t)
-    | Originated(Contract_hash.t);
+    | Originated({
+        contract: Contract_hash.t,
+        entrypoint: option(string),
+      });
 
-  let encoding =
+  let contract_encoding =
     Data_encoding.(
       def(
         "contract_id",
@@ -242,10 +245,10 @@ module Address = {
             Fixed.add_padding(Contract_hash.encoding, 1),
             ~title="Originated",
             fun
-            | Originated(k) => Some(k)
+            | Originated({contract, _}) => Some(contract)
             | _ => None,
-            k =>
-            Originated(k)
+            contract =>
+            Originated({contract, entrypoint: None})
           ),
         ],
       )
@@ -254,18 +257,49 @@ module Address = {
   let to_string =
     fun
     | Implicit(key_hash) => Key_hash.to_string(key_hash)
-    | Originated(contract_hash) => Contract_hash.to_string(contract_hash);
+    | Originated({contract, entrypoint: None}) =>
+      Contract_hash.to_string(contract)
+    | Originated({contract, entrypoint: Some(entrypoint)}) =>
+      Contract_hash.to_string(contract) ++ "%" ++ entrypoint;
   let of_string = {
     let implicit = string => {
       let.some implicit = Key_hash.of_string(string);
       Some(Implicit(implicit));
     };
     let originated = string => {
-      let.some originated = Contract_hash.of_string(string);
-      Some(Originated(originated));
+      let.some (contract, entrypoint) =
+        switch (String.split_on_char('%', string)) {
+        | [contract] => Some((contract, None))
+        | [contract, entrypoint]
+            when String.length(entrypoint) < 32 && entrypoint != "default" =>
+          Some((contract, Some(entrypoint)))
+        | _ => None
+        };
+      let.some contract = Contract_hash.of_string(contract);
+      Some(Originated({contract, entrypoint}));
     };
     try_decode_list([implicit, originated]);
   };
+  let encoding =
+    Data_encoding.(
+      conv(
+        t =>
+          switch (t) {
+          | Implicit(_) as t => (t, "")
+          | Originated({contract: _, entrypoint}) as t =>
+            let entrypoint = Option.value(~default="", entrypoint);
+            (t, entrypoint);
+          },
+        fun
+        // TODO: should we just discard entrypoint of implicit?
+        | (Implicit(_) as t, _) => t
+        | (Originated({contract, _}), "" | "default") =>
+          Originated({contract, entrypoint: None})
+        | (Originated({contract, _}), entrypoint) =>
+          Originated({contract, entrypoint: Some(entrypoint)}),
+        tup2(contract_encoding, Variable.string),
+      )
+    );
 
   let with_yojson_string = (name, of_string, to_string) =>
     Helpers.with_yojson_string(
@@ -311,6 +345,7 @@ module Ticket = {
   open Tezos_micheline;
 
   type t = {
+    // TODO: should we allow implicit contracts here?
     ticketer: Address.t,
     data: bytes,
   };
@@ -370,13 +405,7 @@ module Pack = {
   let key_hash = h =>
     Bytes(-1, Data_encoding.Binary.to_bytes_exn(Key_hash.encoding, h));
   let address = addr =>
-    Bytes(
-      -1,
-      Data_encoding.Binary.to_bytes_exn(
-        Data_encoding.(tup2(Address.encoding, Variable.string)),
-        (addr, ""),
-      ),
-    );
+    Bytes(-1, Data_encoding.Binary.to_bytes_exn(Address.encoding, addr));
   let expr_encoding =
     Micheline.canonical_encoding_v1(
       ~variant="michelson_v1",

--- a/tezos_interop/tezos_interop.rei
+++ b/tezos_interop/tezos_interop.rei
@@ -51,7 +51,10 @@ module Contract_hash: {
 module Address: {
   type t =
     | Implicit(Key_hash.t)
-    | Originated(Contract_hash.t);
+    | Originated({
+        contract: Contract_hash.t,
+        entrypoint: option(string),
+      });
 
   let to_string: t => string;
   let of_string: string => option(t);


### PR DESCRIPTION
## Problem

KT1's in Tezos can actually have an entrypoint in the form of `KT1address%entrypoint`, this is currently not supported by sidechain and it's important to parse Tezos address on #61

## Solution

Here we integrate the entrypoint on `Originated` under `Address.t`, this is not the best solution as technically Tezos supports entrypoints on tz1 but as it's not used anywhere so we just ignore it for now. If this is ever a thing we may need to change some code.

## Related

- #34 
- #61 