### PR TITLE
add JS script to listen for transactions

### DIFF
--- a/esy.lock/index.json
+++ b/esy.lock/index.json
@@ -1,5 +1,5 @@
 {
-  "checksum": "7a1c8c30b81f193463d11335669bffac",
+  "checksum": "e9494ec34c3c16f24162c6099a9b83c3",
   "root": "sidechain@link-dev:./package.json",
   "node": {
     "yocto-queue@0.1.0@d41d8cd9": {
@@ -145,10 +145,10 @@
         "schema-utils@3.1.1@d41d8cd9", "neo-async@2.6.2@d41d8cd9",
         "mime-types@2.1.32@d41d8cd9", "loader-runner@4.2.0@d41d8cd9",
         "json-parse-better-errors@1.0.2@d41d8cd9",
-        "graceful-fs@4.2.6@d41d8cd9", "glob-to-regexp@0.4.1@d41d8cd9",
+        "graceful-fs@4.2.8@d41d8cd9", "glob-to-regexp@0.4.1@d41d8cd9",
         "events@3.3.0@d41d8cd9", "eslint-scope@5.1.1@d41d8cd9",
         "es-module-lexer@0.7.1@d41d8cd9", "enhanced-resolve@5.8.2@d41d8cd9",
-        "chrome-trace-event@1.0.3@d41d8cd9", "browserslist@4.16.6@d41d8cd9",
+        "chrome-trace-event@1.0.3@d41d8cd9", "browserslist@4.16.7@d41d8cd9",
         "acorn-import-assertions@1.7.6@d41d8cd9", "acorn@8.4.1@d41d8cd9",
         "@webassemblyjs/wasm-parser@1.11.1@d41d8cd9",
         "@webassemblyjs/wasm-edit@1.11.1@d41d8cd9",
@@ -169,7 +169,7 @@
       },
       "overrides": [],
       "dependencies": [
-        "graceful-fs@4.2.6@d41d8cd9", "glob-to-regexp@0.4.1@d41d8cd9"
+        "graceful-fs@4.2.8@d41d8cd9", "glob-to-regexp@0.4.1@d41d8cd9"
       ],
       "devDependencies": []
     },
@@ -477,6 +477,7 @@
         "webpack-cli@4.7.2@d41d8cd9", "webpack@5.48.0@d41d8cd9",
         "ocaml@github:esy-ocaml/ocaml#7af70dea28d218eb53bce7966e24dfe6762862ae@d41d8cd9",
         "@taquito/taquito@9.2.0@d41d8cd9", "@taquito/signer@9.2.0@d41d8cd9",
+        "@taquito/rpc@9.2.0@d41d8cd9",
         "@opam/tezos-micheline@opam:8.3@f8cfe30f",
         "@opam/ppx_deriving_yojson@opam:3.6.1@faf11a7c",
         "@opam/ppx_deriving@opam:5.2.1@089e5dd3",
@@ -488,9 +489,9 @@
         "@opam/mirage-crypto-pk@opam:0.10.3@8109ddfe",
         "@opam/mirage-crypto-ec@opam:0.10.3@321b3976",
         "@opam/mirage-crypto@opam:0.10.3@8d7e3bbf",
-        "@opam/lwt@opam:5.4.1@37ffbe37", "@opam/hex@opam:1.4.0@41725494",
+        "@opam/lwt@opam:5.4.2@f5e79982", "@opam/hex@opam:1.4.0@41725494",
         "@opam/dune@opam:2.9.0@489e77a9",
-        "@opam/digestif@opam:1.0.0@0a47b68c",
+        "@opam/digestif@opam:1.0.1@6b318b0d",
         "@opam/cmdliner@opam:1.0.4@93208aac",
         "@esy-ocaml/reason@3.7.0@d41d8cd9"
       ],
@@ -588,7 +589,7 @@
       "overrides": [],
       "dependencies": [
         "ajv-keywords@3.5.2@d41d8cd9", "ajv@6.12.6@d41d8cd9",
-        "@types/json-schema@7.0.8@d41d8cd9"
+        "@types/json-schema@7.0.9@d41d8cd9"
       ],
       "devDependencies": []
     },
@@ -1289,7 +1290,7 @@
       "dependencies": [
         "stack-utils@2.0.3@d41d8cd9", "slash@3.0.0@d41d8cd9",
         "pretty-format@26.6.2@d41d8cd9", "micromatch@4.0.4@d41d8cd9",
-        "graceful-fs@4.2.6@d41d8cd9", "chalk@4.1.2@d41d8cd9",
+        "graceful-fs@4.2.8@d41d8cd9", "chalk@4.1.2@d41d8cd9",
         "@types/stack-utils@2.0.1@d41d8cd9", "@jest/types@26.6.2@d41d8cd9",
         "@babel/code-frame@7.14.5@d41d8cd9"
       ],
@@ -1591,14 +1592,14 @@
       "dependencies": [ "function-bind@1.1.1@d41d8cd9" ],
       "devDependencies": []
     },
-    "graceful-fs@4.2.6@d41d8cd9": {
-      "id": "graceful-fs@4.2.6@d41d8cd9",
+    "graceful-fs@4.2.8@d41d8cd9": {
+      "id": "graceful-fs@4.2.8@d41d8cd9",
       "name": "graceful-fs",
-      "version": "4.2.6",
+      "version": "4.2.8",
       "source": {
         "type": "install",
         "source": [
-          "archive:https://registry.npmjs.org/graceful-fs/-/graceful-fs-4.2.6.tgz#sha1:ff040b2b0853b23c3d31027523706f1885d76bee"
+          "archive:https://registry.npmjs.org/graceful-fs/-/graceful-fs-4.2.8.tgz#sha1:e412b8d33f5e006593cbd3cee6df9f2cebbe802a"
         ]
       },
       "overrides": [],
@@ -1964,7 +1965,7 @@
       },
       "overrides": [],
       "dependencies": [
-        "tapable@2.2.0@d41d8cd9", "graceful-fs@4.2.6@d41d8cd9"
+        "tapable@2.2.0@d41d8cd9", "graceful-fs@4.2.8@d41d8cd9"
       ],
       "devDependencies": []
     },
@@ -1987,14 +1988,14 @@
       ],
       "devDependencies": []
     },
-    "electron-to-chromium@1.3.792@d41d8cd9": {
-      "id": "electron-to-chromium@1.3.792@d41d8cd9",
+    "electron-to-chromium@1.3.796@d41d8cd9": {
+      "id": "electron-to-chromium@1.3.796@d41d8cd9",
       "name": "electron-to-chromium",
-      "version": "1.3.792",
+      "version": "1.3.796",
       "source": {
         "type": "install",
         "source": [
-          "archive:https://registry.npmjs.org/electron-to-chromium/-/electron-to-chromium-1.3.792.tgz#sha1:791b0d8fcf7411885d086193fb49aaef0c1594ca"
+          "archive:https://registry.npmjs.org/electron-to-chromium/-/electron-to-chromium-1.3.796.tgz#sha1:bd74a4367902c9d432d129f265bf4542cddd9f54"
         ]
       },
       "overrides": [],
@@ -2260,14 +2261,14 @@
       ],
       "devDependencies": []
     },
-    "caniuse-lite@1.0.30001248@d41d8cd9": {
-      "id": "caniuse-lite@1.0.30001248@d41d8cd9",
+    "caniuse-lite@1.0.30001249@d41d8cd9": {
+      "id": "caniuse-lite@1.0.30001249@d41d8cd9",
       "name": "caniuse-lite",
-      "version": "1.0.30001248",
+      "version": "1.0.30001249",
       "source": {
         "type": "install",
         "source": [
-          "archive:https://registry.npmjs.org/caniuse-lite/-/caniuse-lite-1.0.30001248.tgz#sha1:26ab45e340f155ea5da2920dadb76a533cb8ebce"
+          "archive:https://registry.npmjs.org/caniuse-lite/-/caniuse-lite-1.0.30001249.tgz#sha1:90a330057f8ff75bfe97a94d047d5e14fabb2ee8"
         ]
       },
       "overrides": [],
@@ -2335,21 +2336,21 @@
       "dependencies": [ "base-x@3.0.8@d41d8cd9" ],
       "devDependencies": []
     },
-    "browserslist@4.16.6@d41d8cd9": {
-      "id": "browserslist@4.16.6@d41d8cd9",
+    "browserslist@4.16.7@d41d8cd9": {
+      "id": "browserslist@4.16.7@d41d8cd9",
       "name": "browserslist",
-      "version": "4.16.6",
+      "version": "4.16.7",
       "source": {
         "type": "install",
         "source": [
-          "archive:https://registry.npmjs.org/browserslist/-/browserslist-4.16.6.tgz#sha1:d7901277a5a88e554ed305b183ec9b0c08f66fa2"
+          "archive:https://registry.npmjs.org/browserslist/-/browserslist-4.16.7.tgz#sha1:108b0d1ef33c4af1b587c54f390e7041178e4335"
         ]
       },
       "overrides": [],
       "dependencies": [
         "node-releases@1.1.73@d41d8cd9", "escalade@3.1.1@d41d8cd9",
-        "electron-to-chromium@1.3.792@d41d8cd9", "colorette@1.2.2@d41d8cd9",
-        "caniuse-lite@1.0.30001248@d41d8cd9"
+        "electron-to-chromium@1.3.796@d41d8cd9", "colorette@1.2.2@d41d8cd9",
+        "caniuse-lite@1.0.30001249@d41d8cd9"
       ],
       "devDependencies": []
     },
@@ -2951,14 +2952,14 @@
       "dependencies": [],
       "devDependencies": []
     },
-    "@types/json-schema@7.0.8@d41d8cd9": {
-      "id": "@types/json-schema@7.0.8@d41d8cd9",
+    "@types/json-schema@7.0.9@d41d8cd9": {
+      "id": "@types/json-schema@7.0.9@d41d8cd9",
       "name": "@types/json-schema",
-      "version": "7.0.8",
+      "version": "7.0.9",
       "source": {
         "type": "install",
         "source": [
-          "archive:https://registry.npmjs.org/@types/json-schema/-/json-schema-7.0.8.tgz#sha1:edf1bf1dbf4e04413ca8e5b17b3b7d7d54b59818"
+          "archive:https://registry.npmjs.org/@types/json-schema/-/json-schema-7.0.9.tgz#sha1:97edc9037ea0c38585320b28964dde3b39e4660d"
         ]
       },
       "overrides": [],
@@ -3049,7 +3050,7 @@
       },
       "overrides": [],
       "dependencies": [
-        "@types/json-schema@7.0.8@d41d8cd9", "@types/estree@0.0.50@d41d8cd9"
+        "@types/json-schema@7.0.9@d41d8cd9", "@types/estree@0.0.50@d41d8cd9"
       ],
       "devDependencies": []
     },
@@ -3518,7 +3519,7 @@
         "@opam/react@opam:1.2.1@0e11855f",
         "@opam/ocamlfind@opam:1.9.1@b748edf6",
         "@opam/lwt_react@opam:1.1.4@7d2054d1",
-        "@opam/lwt@opam:5.4.1@37ffbe37",
+        "@opam/lwt@opam:5.4.2@f5e79982",
         "@opam/lambda-term@opam:3.1.0@ee14e49b",
         "@opam/dune@opam:2.9.0@489e77a9", "@opam/cppo@opam:1.6.7@57a6d52c",
         "@opam/camomile@opam:1.0.2@4c270e23",
@@ -3531,7 +3532,7 @@
         "@opam/react@opam:1.2.1@0e11855f",
         "@opam/ocamlfind@opam:1.9.1@b748edf6",
         "@opam/lwt_react@opam:1.1.4@7d2054d1",
-        "@opam/lwt@opam:5.4.1@37ffbe37",
+        "@opam/lwt@opam:5.4.2@f5e79982",
         "@opam/lambda-term@opam:3.1.0@ee14e49b",
         "@opam/dune@opam:2.9.0@489e77a9",
         "@opam/camomile@opam:1.0.2@4c270e23",
@@ -3727,13 +3728,13 @@
       "overrides": [],
       "dependencies": [
         "ocaml@github:esy-ocaml/ocaml#7af70dea28d218eb53bce7966e24dfe6762862ae@d41d8cd9",
-        "@opam/zarith@opam:1.12@232cc7f2", "@opam/lwt@opam:5.4.1@37ffbe37",
+        "@opam/zarith@opam:1.12@232cc7f2", "@opam/lwt@opam:5.4.2@f5e79982",
         "@opam/hex@opam:1.4.0@41725494", "@opam/dune@opam:2.9.0@489e77a9",
         "@esy-ocaml/substs@0.0.1@d41d8cd9"
       ],
       "devDependencies": [
         "ocaml@github:esy-ocaml/ocaml#7af70dea28d218eb53bce7966e24dfe6762862ae@d41d8cd9",
-        "@opam/zarith@opam:1.12@232cc7f2", "@opam/lwt@opam:5.4.1@37ffbe37",
+        "@opam/zarith@opam:1.12@232cc7f2", "@opam/lwt@opam:5.4.2@f5e79982",
         "@opam/hex@opam:1.4.0@41725494", "@opam/dune@opam:2.9.0@489e77a9"
       ]
     },
@@ -4059,7 +4060,7 @@
       "dependencies": [
         "ocaml@github:esy-ocaml/ocaml#7af70dea28d218eb53bce7966e24dfe6762862ae@d41d8cd9",
         "@opam/sexplib0@opam:v0.14.0@155c136c",
-        "@opam/lwt@opam:5.4.1@37ffbe37",
+        "@opam/lwt@opam:5.4.2@f5e79982",
         "@opam/httpaf@github:anmonteiro/httpaf:httpaf.opam#559019829b7ed267a5b4b86aed1e7d7795214bcd@d41d8cd9",
         "@opam/hmap@opam:0.8.1@87a77ebe", "@opam/dune@opam:2.9.0@489e77a9",
         "@opam/bigstringaf@opam:0.8.0@6a362afb",
@@ -4068,7 +4069,7 @@
       "devDependencies": [
         "ocaml@github:esy-ocaml/ocaml#7af70dea28d218eb53bce7966e24dfe6762862ae@d41d8cd9",
         "@opam/sexplib0@opam:v0.14.0@155c136c",
-        "@opam/lwt@opam:5.4.1@37ffbe37",
+        "@opam/lwt@opam:5.4.2@f5e79982",
         "@opam/httpaf@github:anmonteiro/httpaf:httpaf.opam#559019829b7ed267a5b4b86aed1e7d7795214bcd@d41d8cd9",
         "@opam/hmap@opam:0.8.1@87a77ebe", "@opam/dune@opam:2.9.0@489e77a9",
         "@opam/bigstringaf@opam:0.8.0@6a362afb"
@@ -4471,7 +4472,7 @@
         "@opam/psq@opam:0.2.0@e2fd474c", "@opam/pecu@opam:0.6@9b1d46f4",
         "@opam/mrmime@opam:0.3.2@2b4fe265",
         "@opam/magic-mime@opam:1.2.0@6a509c98",
-        "@opam/lwt_ssl@opam:1.1.3@653af026", "@opam/lwt@opam:5.4.1@37ffbe37",
+        "@opam/lwt_ssl@opam:1.1.3@653af026", "@opam/lwt@opam:5.4.2@f5e79982",
         "@opam/logs@opam:0.7.0@1d03143e",
         "@opam/httpaf-lwt-unix@github:anmonteiro/httpaf:httpaf-lwt-unix.opam#559019829b7ed267a5b4b86aed1e7d7795214bcd@d41d8cd9",
         "@opam/httpaf@github:anmonteiro/httpaf:httpaf.opam#559019829b7ed267a5b4b86aed1e7d7795214bcd@d41d8cd9",
@@ -4490,7 +4491,7 @@
         "@opam/psq@opam:0.2.0@e2fd474c", "@opam/pecu@opam:0.6@9b1d46f4",
         "@opam/mrmime@opam:0.3.2@2b4fe265",
         "@opam/magic-mime@opam:1.2.0@6a509c98",
-        "@opam/lwt_ssl@opam:1.1.3@653af026", "@opam/lwt@opam:5.4.1@37ffbe37",
+        "@opam/lwt_ssl@opam:1.1.3@653af026", "@opam/lwt@opam:5.4.2@f5e79982",
         "@opam/logs@opam:0.7.0@1d03143e",
         "@opam/httpaf-lwt-unix@github:anmonteiro/httpaf:httpaf-lwt-unix.opam#559019829b7ed267a5b4b86aed1e7d7795214bcd@d41d8cd9",
         "@opam/httpaf@github:anmonteiro/httpaf:httpaf.opam#559019829b7ed267a5b4b86aed1e7d7795214bcd@d41d8cd9",
@@ -4581,7 +4582,7 @@
         "@opam/mtime@opam:1.2.0@acd670b8",
         "@opam/mirage-crypto@opam:0.10.3@8d7e3bbf",
         "@opam/magic-mime@opam:1.2.0@6a509c98",
-        "@opam/lwt@opam:5.4.1@37ffbe37", "@opam/logs@opam:0.7.0@1d03143e",
+        "@opam/lwt@opam:5.4.2@f5e79982", "@opam/logs@opam:0.7.0@1d03143e",
         "@opam/httpaf-lwt-unix@github:anmonteiro/httpaf:httpaf-lwt-unix.opam#559019829b7ed267a5b4b86aed1e7d7795214bcd@d41d8cd9",
         "@opam/fmt@opam:0.8.9@e0843a5b", "@opam/dune@opam:2.9.0@489e77a9",
         "@opam/cmdliner@opam:1.0.4@93208aac",
@@ -4600,7 +4601,7 @@
         "@opam/mtime@opam:1.2.0@acd670b8",
         "@opam/mirage-crypto@opam:0.10.3@8d7e3bbf",
         "@opam/magic-mime@opam:1.2.0@6a509c98",
-        "@opam/lwt@opam:5.4.1@37ffbe37", "@opam/logs@opam:0.7.0@1d03143e",
+        "@opam/lwt@opam:5.4.2@f5e79982", "@opam/logs@opam:0.7.0@1d03143e",
         "@opam/httpaf-lwt-unix@github:anmonteiro/httpaf:httpaf-lwt-unix.opam#559019829b7ed267a5b4b86aed1e7d7795214bcd@d41d8cd9",
         "@opam/fmt@opam:0.8.9@e0843a5b", "@opam/dune@opam:2.9.0@489e77a9",
         "@opam/cmdliner@opam:1.0.4@93208aac",
@@ -4980,12 +4981,12 @@
       "overrides": [],
       "dependencies": [
         "@opam/stringext@opam:1.6.0@d9079793",
-        "@opam/lwt_ppx@opam:2.0.2@d18729de", "@opam/lwt@opam:5.4.1@37ffbe37",
+        "@opam/lwt_ppx@opam:2.0.2@d18729de", "@opam/lwt@opam:5.4.2@f5e79982",
         "@opam/dune@opam:2.9.0@489e77a9", "@esy-ocaml/substs@0.0.1@d41d8cd9"
       ],
       "devDependencies": [
         "@opam/stringext@opam:1.6.0@d9079793",
-        "@opam/lwt_ppx@opam:2.0.2@d18729de", "@opam/lwt@opam:5.4.1@37ffbe37",
+        "@opam/lwt_ppx@opam:2.0.2@d18729de", "@opam/lwt@opam:5.4.2@f5e79982",
         "@opam/dune@opam:2.9.0@489e77a9"
       ]
     },
@@ -5164,8 +5165,8 @@
         "ocaml@github:esy-ocaml/ocaml#7af70dea28d218eb53bce7966e24dfe6762862ae@d41d8cd9",
         "@opam/mtime@opam:1.2.0@acd670b8",
         "@opam/mirage-crypto@opam:0.10.3@8d7e3bbf",
-        "@opam/lwt@opam:5.4.1@37ffbe37", "@opam/logs@opam:0.7.0@1d03143e",
-        "@opam/duration@opam:0.1.3@90245962",
+        "@opam/lwt@opam:5.4.2@f5e79982", "@opam/logs@opam:0.7.0@1d03143e",
+        "@opam/duration@opam:0.2.0@385467fd",
         "@opam/dune-configurator@opam:2.9.0@40e837e7",
         "@opam/dune@opam:2.9.0@489e77a9",
         "@opam/cstruct@opam:6.0.1@69eae449",
@@ -5175,8 +5176,8 @@
         "ocaml@github:esy-ocaml/ocaml#7af70dea28d218eb53bce7966e24dfe6762862ae@d41d8cd9",
         "@opam/mtime@opam:1.2.0@acd670b8",
         "@opam/mirage-crypto@opam:0.10.3@8d7e3bbf",
-        "@opam/lwt@opam:5.4.1@37ffbe37", "@opam/logs@opam:0.7.0@1d03143e",
-        "@opam/duration@opam:0.1.3@90245962",
+        "@opam/lwt@opam:5.4.2@f5e79982", "@opam/logs@opam:0.7.0@1d03143e",
+        "@opam/duration@opam:0.2.0@385467fd",
         "@opam/dune-configurator@opam:2.9.0@40e837e7",
         "@opam/dune@opam:2.9.0@489e77a9", "@opam/cstruct@opam:6.0.1@69eae449"
       ]
@@ -5537,14 +5538,14 @@
       "dependencies": [
         "ocaml@github:esy-ocaml/ocaml#7af70dea28d218eb53bce7966e24dfe6762862ae@d41d8cd9",
         "@opam/ssl@github:Firgeis/ocaml-ssl:ssl.opam#f7524f7b6db756ce4097dea7fa4e1c4f4f2832a9@d41d8cd9",
-        "@opam/lwt@opam:5.4.1@37ffbe37", "@opam/dune@opam:2.9.0@489e77a9",
+        "@opam/lwt@opam:5.4.2@f5e79982", "@opam/dune@opam:2.9.0@489e77a9",
         "@opam/base-unix@opam:base@87d0b2eb",
         "@esy-ocaml/substs@0.0.1@d41d8cd9"
       ],
       "devDependencies": [
         "ocaml@github:esy-ocaml/ocaml#7af70dea28d218eb53bce7966e24dfe6762862ae@d41d8cd9",
         "@opam/ssl@github:Firgeis/ocaml-ssl:ssl.opam#f7524f7b6db756ce4097dea7fa4e1c4f4f2832a9@d41d8cd9",
-        "@opam/lwt@opam:5.4.1@37ffbe37", "@opam/dune@opam:2.9.0@489e77a9",
+        "@opam/lwt@opam:5.4.2@f5e79982", "@opam/dune@opam:2.9.0@489e77a9",
         "@opam/base-unix@opam:base@87d0b2eb"
       ]
     },
@@ -5567,12 +5568,12 @@
       "overrides": [],
       "dependencies": [
         "ocaml@github:esy-ocaml/ocaml#7af70dea28d218eb53bce7966e24dfe6762862ae@d41d8cd9",
-        "@opam/react@opam:1.2.1@0e11855f", "@opam/lwt@opam:5.4.1@37ffbe37",
+        "@opam/react@opam:1.2.1@0e11855f", "@opam/lwt@opam:5.4.2@f5e79982",
         "@opam/dune@opam:2.9.0@489e77a9", "@esy-ocaml/substs@0.0.1@d41d8cd9"
       ],
       "devDependencies": [
         "ocaml@github:esy-ocaml/ocaml#7af70dea28d218eb53bce7966e24dfe6762862ae@d41d8cd9",
-        "@opam/react@opam:1.2.1@0e11855f", "@opam/lwt@opam:5.4.1@37ffbe37",
+        "@opam/react@opam:1.2.1@0e11855f", "@opam/lwt@opam:5.4.2@f5e79982",
         "@opam/dune@opam:2.9.0@489e77a9"
       ]
     },
@@ -5595,12 +5596,12 @@
       "overrides": [],
       "dependencies": [
         "ocaml@github:esy-ocaml/ocaml#7af70dea28d218eb53bce7966e24dfe6762862ae@d41d8cd9",
-        "@opam/ppxlib@opam:0.22.2@61009929", "@opam/lwt@opam:5.4.1@37ffbe37",
+        "@opam/ppxlib@opam:0.22.2@61009929", "@opam/lwt@opam:5.4.2@f5e79982",
         "@opam/dune@opam:2.9.0@489e77a9", "@esy-ocaml/substs@0.0.1@d41d8cd9"
       ],
       "devDependencies": [
         "ocaml@github:esy-ocaml/ocaml#7af70dea28d218eb53bce7966e24dfe6762862ae@d41d8cd9",
-        "@opam/ppxlib@opam:0.22.2@61009929", "@opam/lwt@opam:5.4.1@37ffbe37",
+        "@opam/ppxlib@opam:0.22.2@61009929", "@opam/lwt@opam:5.4.2@f5e79982",
         "@opam/dune@opam:2.9.0@489e77a9"
       ]
     },
@@ -5622,11 +5623,11 @@
       },
       "overrides": [],
       "dependencies": [
-        "@opam/lwt@opam:5.4.1@37ffbe37", "@opam/dune@opam:2.9.0@489e77a9",
+        "@opam/lwt@opam:5.4.2@f5e79982", "@opam/dune@opam:2.9.0@489e77a9",
         "@esy-ocaml/substs@0.0.1@d41d8cd9"
       ],
       "devDependencies": [
-        "@opam/lwt@opam:5.4.1@37ffbe37", "@opam/dune@opam:2.9.0@489e77a9"
+        "@opam/lwt@opam:5.4.2@f5e79982", "@opam/dune@opam:2.9.0@489e77a9"
       ]
     },
     "@opam/lwt-canceler@opam:0.2@a2941d49": {
@@ -5648,28 +5649,28 @@
       "overrides": [],
       "dependencies": [
         "ocaml@github:esy-ocaml/ocaml#7af70dea28d218eb53bce7966e24dfe6762862ae@d41d8cd9",
-        "@opam/lwt@opam:5.4.1@37ffbe37", "@opam/dune@opam:2.9.0@489e77a9",
+        "@opam/lwt@opam:5.4.2@f5e79982", "@opam/dune@opam:2.9.0@489e77a9",
         "@esy-ocaml/substs@0.0.1@d41d8cd9"
       ],
       "devDependencies": [
         "ocaml@github:esy-ocaml/ocaml#7af70dea28d218eb53bce7966e24dfe6762862ae@d41d8cd9",
-        "@opam/lwt@opam:5.4.1@37ffbe37", "@opam/dune@opam:2.9.0@489e77a9"
+        "@opam/lwt@opam:5.4.2@f5e79982", "@opam/dune@opam:2.9.0@489e77a9"
       ]
     },
-    "@opam/lwt@opam:5.4.1@37ffbe37": {
-      "id": "@opam/lwt@opam:5.4.1@37ffbe37",
+    "@opam/lwt@opam:5.4.2@f5e79982": {
+      "id": "@opam/lwt@opam:5.4.2@f5e79982",
       "name": "@opam/lwt",
-      "version": "opam:5.4.1",
+      "version": "opam:5.4.2",
       "source": {
         "type": "install",
         "source": [
-          "archive:https://opam.ocaml.org/cache/md5/5a/5a8d2a83ee9314781f137d147a4c62ae#md5:5a8d2a83ee9314781f137d147a4c62ae",
-          "archive:https://github.com/ocsigen/lwt/archive/refs/tags/5.4.1.tar.gz#md5:5a8d2a83ee9314781f137d147a4c62ae"
+          "archive:https://opam.ocaml.org/cache/md5/ba/ba3659a8918d8e7cb0f4ef9a83945f90#md5:ba3659a8918d8e7cb0f4ef9a83945f90",
+          "archive:https://github.com/ocsigen/lwt/archive/refs/tags/5.4.2.tar.gz#md5:ba3659a8918d8e7cb0f4ef9a83945f90"
         ],
         "opam": {
           "name": "lwt",
-          "version": "5.4.1",
-          "path": "esy.lock/opam/lwt.5.4.1"
+          "version": "5.4.2",
+          "path": "esy.lock/opam/lwt.5.4.2"
         }
       },
       "overrides": [],
@@ -5717,7 +5718,7 @@
         "@opam/topkg@opam:1.0.3@e4e10f1c",
         "@opam/ocamlfind@opam:1.9.1@b748edf6",
         "@opam/ocamlbuild@opam:0.14.0@6ac75d03",
-        "@opam/lwt@opam:5.4.1@37ffbe37", "@opam/fmt@opam:0.8.9@e0843a5b",
+        "@opam/lwt@opam:5.4.2@f5e79982", "@opam/fmt@opam:0.8.9@e0843a5b",
         "@opam/cmdliner@opam:1.0.4@93208aac",
         "@opam/base-threads@opam:base@36803084",
         "@esy-ocaml/substs@0.0.1@d41d8cd9"
@@ -5748,7 +5749,7 @@
         "@opam/zed@opam:3.1.0@86c55416", "@opam/react@opam:1.2.1@0e11855f",
         "@opam/mew_vi@opam:0.5.0@cf66c299",
         "@opam/lwt_react@opam:1.1.4@7d2054d1",
-        "@opam/lwt_log@opam:1.1.1@fc97477f", "@opam/lwt@opam:5.4.1@37ffbe37",
+        "@opam/lwt_log@opam:1.1.1@fc97477f", "@opam/lwt@opam:5.4.2@f5e79982",
         "@opam/dune@opam:2.9.0@489e77a9",
         "@opam/camomile@opam:1.0.2@4c270e23",
         "@esy-ocaml/substs@0.0.1@d41d8cd9"
@@ -5758,7 +5759,7 @@
         "@opam/zed@opam:3.1.0@86c55416", "@opam/react@opam:1.2.1@0e11855f",
         "@opam/mew_vi@opam:0.5.0@cf66c299",
         "@opam/lwt_react@opam:1.1.4@7d2054d1",
-        "@opam/lwt_log@opam:1.1.1@fc97477f", "@opam/lwt@opam:5.4.1@37ffbe37",
+        "@opam/lwt_log@opam:1.1.1@fc97477f", "@opam/lwt@opam:5.4.2@f5e79982",
         "@opam/dune@opam:2.9.0@489e77a9",
         "@opam/camomile@opam:1.0.2@4c270e23"
       ]
@@ -5953,7 +5954,7 @@
       "overrides": [],
       "dependencies": [
         "ocaml@github:esy-ocaml/ocaml#7af70dea28d218eb53bce7966e24dfe6762862ae@d41d8cd9",
-        "@opam/lwt@opam:5.4.1@37ffbe37",
+        "@opam/lwt@opam:5.4.2@f5e79982",
         "@opam/httpaf-lwt@github:anmonteiro/httpaf:httpaf-lwt.opam#559019829b7ed267a5b4b86aed1e7d7795214bcd@d41d8cd9",
         "@opam/httpaf@github:anmonteiro/httpaf:httpaf.opam#559019829b7ed267a5b4b86aed1e7d7795214bcd@d41d8cd9",
         "@opam/gluten-lwt-unix@opam:0.2.1@1a92c47e",
@@ -5962,7 +5963,7 @@
       ],
       "devDependencies": [
         "ocaml@github:esy-ocaml/ocaml#7af70dea28d218eb53bce7966e24dfe6762862ae@d41d8cd9",
-        "@opam/lwt@opam:5.4.1@37ffbe37",
+        "@opam/lwt@opam:5.4.2@f5e79982",
         "@opam/httpaf-lwt@github:anmonteiro/httpaf:httpaf-lwt.opam#559019829b7ed267a5b4b86aed1e7d7795214bcd@d41d8cd9",
         "@opam/httpaf@github:anmonteiro/httpaf:httpaf.opam#559019829b7ed267a5b4b86aed1e7d7795214bcd@d41d8cd9",
         "@opam/gluten-lwt-unix@opam:0.2.1@1a92c47e",
@@ -5985,14 +5986,14 @@
       "overrides": [],
       "dependencies": [
         "ocaml@github:esy-ocaml/ocaml#7af70dea28d218eb53bce7966e24dfe6762862ae@d41d8cd9",
-        "@opam/lwt@opam:5.4.1@37ffbe37",
+        "@opam/lwt@opam:5.4.2@f5e79982",
         "@opam/httpaf@github:anmonteiro/httpaf:httpaf.opam#559019829b7ed267a5b4b86aed1e7d7795214bcd@d41d8cd9",
         "@opam/gluten-lwt@opam:0.2.1@4dbee72c",
         "@opam/dune@opam:2.9.0@489e77a9", "@esy-ocaml/substs@0.0.1@d41d8cd9"
       ],
       "devDependencies": [
         "ocaml@github:esy-ocaml/ocaml#7af70dea28d218eb53bce7966e24dfe6762862ae@d41d8cd9",
-        "@opam/lwt@opam:5.4.1@37ffbe37",
+        "@opam/lwt@opam:5.4.2@f5e79982",
         "@opam/httpaf@github:anmonteiro/httpaf:httpaf.opam#559019829b7ed267a5b4b86aed1e7d7795214bcd@d41d8cd9",
         "@opam/gluten-lwt@opam:0.2.1@4dbee72c",
         "@opam/dune@opam:2.9.0@489e77a9"
@@ -6107,7 +6108,7 @@
       "overrides": [],
       "dependencies": [
         "ocaml@github:esy-ocaml/ocaml#7af70dea28d218eb53bce7966e24dfe6762862ae@d41d8cd9",
-        "@opam/lwt_ssl@opam:1.1.3@653af026", "@opam/lwt@opam:5.4.1@37ffbe37",
+        "@opam/lwt_ssl@opam:1.1.3@653af026", "@opam/lwt@opam:5.4.2@f5e79982",
         "@opam/gluten-lwt@opam:0.2.1@4dbee72c",
         "@opam/gluten@opam:0.2.1@fca26440",
         "@opam/faraday-lwt-unix@opam:0.8.1@e733b134",
@@ -6115,7 +6116,7 @@
       ],
       "devDependencies": [
         "ocaml@github:esy-ocaml/ocaml#7af70dea28d218eb53bce7966e24dfe6762862ae@d41d8cd9",
-        "@opam/lwt@opam:5.4.1@37ffbe37",
+        "@opam/lwt@opam:5.4.2@f5e79982",
         "@opam/gluten-lwt@opam:0.2.1@4dbee72c",
         "@opam/gluten@opam:0.2.1@fca26440",
         "@opam/faraday-lwt-unix@opam:0.8.1@e733b134",
@@ -6141,12 +6142,12 @@
       "overrides": [],
       "dependencies": [
         "ocaml@github:esy-ocaml/ocaml#7af70dea28d218eb53bce7966e24dfe6762862ae@d41d8cd9",
-        "@opam/lwt@opam:5.4.1@37ffbe37", "@opam/gluten@opam:0.2.1@fca26440",
+        "@opam/lwt@opam:5.4.2@f5e79982", "@opam/gluten@opam:0.2.1@fca26440",
         "@opam/dune@opam:2.9.0@489e77a9", "@esy-ocaml/substs@0.0.1@d41d8cd9"
       ],
       "devDependencies": [
         "ocaml@github:esy-ocaml/ocaml#7af70dea28d218eb53bce7966e24dfe6762862ae@d41d8cd9",
-        "@opam/lwt@opam:5.4.1@37ffbe37", "@opam/gluten@opam:0.2.1@fca26440",
+        "@opam/lwt@opam:5.4.2@f5e79982", "@opam/gluten@opam:0.2.1@fca26440",
         "@opam/dune@opam:2.9.0@489e77a9"
       ]
     },
@@ -6290,7 +6291,7 @@
       "overrides": [],
       "dependencies": [
         "ocaml@github:esy-ocaml/ocaml#7af70dea28d218eb53bce7966e24dfe6762862ae@d41d8cd9",
-        "@opam/lwt@opam:5.4.1@37ffbe37",
+        "@opam/lwt@opam:5.4.2@f5e79982",
         "@opam/faraday-lwt@opam:0.8.1@5a6331d0",
         "@opam/dune@opam:2.9.0@489e77a9",
         "@opam/base-unix@opam:base@87d0b2eb",
@@ -6298,7 +6299,7 @@
       ],
       "devDependencies": [
         "ocaml@github:esy-ocaml/ocaml#7af70dea28d218eb53bce7966e24dfe6762862ae@d41d8cd9",
-        "@opam/lwt@opam:5.4.1@37ffbe37",
+        "@opam/lwt@opam:5.4.2@f5e79982",
         "@opam/faraday-lwt@opam:0.8.1@5a6331d0",
         "@opam/dune@opam:2.9.0@489e77a9",
         "@opam/base-unix@opam:base@87d0b2eb"
@@ -6323,12 +6324,12 @@
       "overrides": [],
       "dependencies": [
         "ocaml@github:esy-ocaml/ocaml#7af70dea28d218eb53bce7966e24dfe6762862ae@d41d8cd9",
-        "@opam/lwt@opam:5.4.1@37ffbe37", "@opam/faraday@opam:0.8.1@3e04a493",
+        "@opam/lwt@opam:5.4.2@f5e79982", "@opam/faraday@opam:0.8.1@3e04a493",
         "@opam/dune@opam:2.9.0@489e77a9", "@esy-ocaml/substs@0.0.1@d41d8cd9"
       ],
       "devDependencies": [
         "ocaml@github:esy-ocaml/ocaml#7af70dea28d218eb53bce7966e24dfe6762862ae@d41d8cd9",
-        "@opam/lwt@opam:5.4.1@37ffbe37", "@opam/faraday@opam:0.8.1@3e04a493",
+        "@opam/lwt@opam:5.4.2@f5e79982", "@opam/faraday@opam:0.8.1@3e04a493",
         "@opam/dune@opam:2.9.0@489e77a9"
       ]
     },
@@ -6482,20 +6483,20 @@
         "@opam/dune@opam:2.9.0@489e77a9"
       ]
     },
-    "@opam/duration@opam:0.1.3@90245962": {
-      "id": "@opam/duration@opam:0.1.3@90245962",
+    "@opam/duration@opam:0.2.0@385467fd": {
+      "id": "@opam/duration@opam:0.2.0@385467fd",
       "name": "@opam/duration",
-      "version": "opam:0.1.3",
+      "version": "opam:0.2.0",
       "source": {
         "type": "install",
         "source": [
-          "archive:https://opam.ocaml.org/cache/sha256/b0/b0a41b0487b79d1e6447bbb048a32447684b296b72e5de767a28d10bbd023955#sha256:b0a41b0487b79d1e6447bbb048a32447684b296b72e5de767a28d10bbd023955",
-          "archive:https://github.com/hannesm/duration/releases/download/0.1.3/duration-0.1.3.tbz#sha256:b0a41b0487b79d1e6447bbb048a32447684b296b72e5de767a28d10bbd023955"
+          "archive:https://opam.ocaml.org/cache/sha256/ad/ad14fb75a5a6f73fff7ef1721178925ee555cf0f23b23e3ab329184bc0c1ce69#sha256:ad14fb75a5a6f73fff7ef1721178925ee555cf0f23b23e3ab329184bc0c1ce69",
+          "archive:https://github.com/hannesm/duration/releases/download/0.2.0/duration-0.2.0.tbz#sha256:ad14fb75a5a6f73fff7ef1721178925ee555cf0f23b23e3ab329184bc0c1ce69"
         ],
         "opam": {
           "name": "duration",
-          "version": "0.1.3",
-          "path": "esy.lock/opam/duration.0.1.3"
+          "version": "0.2.0",
+          "path": "esy.lock/opam/duration.0.2.0"
         }
       },
       "overrides": [],
@@ -6647,20 +6648,20 @@
         "@opam/astring@opam:0.8.5@1300cee8"
       ]
     },
-    "@opam/digestif@opam:1.0.0@0a47b68c": {
-      "id": "@opam/digestif@opam:1.0.0@0a47b68c",
+    "@opam/digestif@opam:1.0.1@6b318b0d": {
+      "id": "@opam/digestif@opam:1.0.1@6b318b0d",
       "name": "@opam/digestif",
-      "version": "opam:1.0.0",
+      "version": "opam:1.0.1",
       "source": {
         "type": "install",
         "source": [
-          "archive:https://opam.ocaml.org/cache/sha256/29/29450c1fecb93b3c5c19588f8abcbf4891ddf1f84a1bbd3fb860e96994472884#sha256:29450c1fecb93b3c5c19588f8abcbf4891ddf1f84a1bbd3fb860e96994472884",
-          "archive:https://github.com/mirage/digestif/releases/download/v1.0.0/digestif-v1.0.0.tbz#sha256:29450c1fecb93b3c5c19588f8abcbf4891ddf1f84a1bbd3fb860e96994472884"
+          "archive:https://opam.ocaml.org/cache/sha256/cd/cd7d6e706ce3592fd80c57f241a09f565bd71fecbf730c3611c33a6b3803a2b8#sha256:cd7d6e706ce3592fd80c57f241a09f565bd71fecbf730c3611c33a6b3803a2b8",
+          "archive:https://github.com/mirage/digestif/releases/download/v1.0.1/digestif-v1.0.1.tbz#sha256:cd7d6e706ce3592fd80c57f241a09f565bd71fecbf730c3611c33a6b3803a2b8"
         ],
         "opam": {
           "name": "digestif",
-          "version": "1.0.0",
-          "path": "esy.lock/opam/digestif.1.0.0"
+          "version": "1.0.1",
+          "path": "esy.lock/opam/digestif.1.0.1"
         }
       },
       "overrides": [],

--- a/esy.lock/opam/digestif.1.0.1/opam
+++ b/esy.lock/opam/digestif.1.0.1/opam
@@ -60,13 +60,12 @@ conflicts: [
   "mirage-xen" {< "6.0.0"}
   "ocaml-freestanding" {< "0.6.0"}
 ]
-x-commit-hash: "f7e043938d9bb6fda9865086074e60929095cd9e"
 url {
   src:
-    "https://github.com/mirage/digestif/releases/download/v1.0.0/digestif-v1.0.0.tbz"
+    "https://github.com/mirage/digestif/releases/download/v1.0.1/digestif-v1.0.1.tbz"
   checksum: [
-    "sha256=29450c1fecb93b3c5c19588f8abcbf4891ddf1f84a1bbd3fb860e96994472884"
-    "sha512=30f4e2ea85a0aa50dbafb7c52d55b49f5612fbeeaa4ed8bfbd1610848a8f397c4cd1589fe0bd7ab3f165974697151279d56c37bae44c7f29a2d5a514af9d4942"
+    "sha256=cd7d6e706ce3592fd80c57f241a09f565bd71fecbf730c3611c33a6b3803a2b8"
+    "sha512=3e71393eafa9769bf44adc806121f7e27692f0d9c437032c701d7f11a4abbfb139115e02a4fa863516f9e554b8f69cf28660c720a9c9724b768e3f88e6af2a8a"
   ]
 }
-available: [ arch != "s390x" ]
+x-commit-hash: "60fe6894be50d94932a54c91ad77a435a4565ffd"

--- a/esy.lock/opam/duration.0.2.0/opam
+++ b/esy.lock/opam/duration.0.2.0/opam
@@ -24,9 +24,10 @@ on negative or out of bound input.
 """
 url {
   src:
-    "https://github.com/hannesm/duration/releases/download/0.1.3/duration-0.1.3.tbz"
+    "https://github.com/hannesm/duration/releases/download/0.2.0/duration-0.2.0.tbz"
   checksum: [
-    "sha256=b0a41b0487b79d1e6447bbb048a32447684b296b72e5de767a28d10bbd023955"
-    "sha512=e7c0270f9e32adecee3c1e25e25c560f646360f146162a66ef15c7231b991cb746178ab806c35feb3494b78f978659db83e9c895329886e76c09f8a0facbd0f2"
+    "sha256=ad14fb75a5a6f73fff7ef1721178925ee555cf0f23b23e3ab329184bc0c1ce69"
+    "sha512=6a259ca406739bfc6020c7de767e39c2a7ee06169aa1966d43d426b2a54fc69b81be6465d04b9bd8fbbbbfd9ebe1c82a1cbfbf62100a37eb0f7403f6cf53e3b8"
   ]
 }
+x-commit-hash: "ec2b9a36901d1902cc90d202a8987d7e3b3e63df"

--- a/esy.lock/opam/lwt.5.4.2/opam
+++ b/esy.lock/opam/lwt.5.4.2/opam
@@ -1,7 +1,6 @@
 opam-version: "2.0"
 
 synopsis: "Promises and event-driven I/O"
-
 license: "MIT"
 homepage: "https://github.com/ocsigen/lwt"
 doc: "https://ocsigen.org/lwt"
@@ -58,9 +57,9 @@ Meanwhile, OCaml code, including code creating and waiting on promises, runs in
 a single thread by default. This reduces the need for locks or other
 synchronization primitives. Code can be run in parallel on an opt-in basis."
 url {
-  src: "https://github.com/ocsigen/lwt/archive/refs/tags/5.4.1.tar.gz"
+  src: "https://github.com/ocsigen/lwt/archive/refs/tags/5.4.2.tar.gz"
   checksum: [
-    "md5=5a8d2a83ee9314781f137d147a4c62ae"
-    "sha512=b872b7abe546c431ba62fe466423d7ace8e487ebd85ea5e859f462eb4c0a6884b242d9efd4a557b6da3ae699b0b695e0a783f89a1d1147cba7d99c4ae9d2db17"
+    "md5=ba3659a8918d8e7cb0f4ef9a83945f90"
+    "sha512=9f46fb2e56dc7bd57a12d5ab4dc68719947a1462f336087a95e991d087bb9b5b8dee2592d0f7d35abc507d9a641dd221c44c949c81d00e26c673a067d94ba3f4"
   ]
 }

--- a/package.json
+++ b/package.json
@@ -37,6 +37,7 @@
     "@opam/cmdliner": "1.0.4",
     "@taquito/taquito": "^9.0.1",
     "@taquito/signer": "^9.0.1",
+    "@taquito/rpc": "^9.0.1",
     "webpack": "^5.47.1",
     "webpack-cli": "^4.7.1",
     "@opam/ppx_blob": "*"

--- a/tezos_interop/dune
+++ b/tezos_interop/dune
@@ -4,11 +4,12 @@
  (preprocess
   (pps ppx_deriving_yojson ppx_blob))
  (preprocessor_deps
-  (file ./run_entrypoint.bundle.js)))
+  (file ./run_entrypoint.bundle.js)
+  (file ./listen_transactions.bundle.js)))
 
 (rule
- (deps ./webpack.config.js ./run_entrypoint.js)
- (targets ./run_entrypoint.bundle.js)
+ (deps ./webpack.config.js ./listen_transactions.js ./run_entrypoint.js)
+ (targets ./listen_transactions.bundle.js ./run_entrypoint.bundle.js)
  (mode fallback)
  (action
   (run webpack --env=%{profile})))

--- a/tezos_interop/listen_transactions.js
+++ b/tezos_interop/listen_transactions.js
@@ -1,0 +1,89 @@
+"use strict";
+
+const fs = require("fs");
+const taquito = require("@taquito/taquito");
+const rpc = require("@taquito/rpc");
+const { TezosToolkit } = require("@taquito/taquito");
+
+/**
+ * @typedef Input
+ * @type {object}
+ * @property {string} rpc_node
+ * @property {number} confirmation
+ * @property {string} destination
+ */
+/** @returns {Input} */
+const input = () => JSON.parse(fs.readFileSync(process.stdin.fd));
+
+const error = (err) => {
+  console.error(err);
+  process.exit();
+};
+
+/**
+ * @typedef Transaction
+ * @type {object}
+ * @property {string} hash
+ * @property {number} index
+ * @property {string} entrypoint
+ * @property {rpc.MichelsonV1Expression} value
+ */
+/** @param {Transaction} transaction */
+const output = (transaction) => {
+  const callback = (err) => err && error(err);
+  process.stdout.write(JSON.stringify(transaction), callback);
+  process.stdout.write("\n", callback);
+};
+
+const { rpc_node, confirmation, destination } = input();
+
+const Tezos = new TezosToolkit(rpc_node);
+
+const operationStream = Tezos.stream.subscribeOperation({
+  kind: taquito.OpKind.TRANSACTION,
+});
+
+operationStream.on("error", error);
+operationStream.on("data", async (content) => {
+  /** @type {rpc.OperationContentsAndResultMetadataTransaction} */
+  const metadata = content.metadata;
+  if (content.kind !== taquito.OpKind.TRANSACTION
+    || metadata.operation_result.status !== "applied") {
+    return;
+  }
+  try {
+    const hash = content.hash;
+
+    let operations = (metadata.internal_operation_results || [])
+      .filter(
+        (operation) =>
+          operation.kind === taquito.OpKind.TRANSACTION &&
+          operation.destination === destination
+      )
+      .map((operation) => operation.parameters);
+
+    operations =
+      content.destination === destination
+        ? [content.parameters, ...operations]
+        : operations;
+    operations = operations.filter(Boolean).map((parameters, index) => ({
+      ...parameters,
+      hash,
+      index,
+    }));
+
+    if (operations.length === 0) {
+      return;
+    }
+
+    const operation = await Tezos.operation.createTransactionOperation(hash);
+
+    const result = await operation.confirmation(confirmation);
+    if (await result.isInCurrentBranch()) {
+      operations.forEach(output);
+    }
+  } catch (err) {
+    console.error(err);
+    // TODO: what happens here? I feel like this is a noop
+  }
+});

--- a/tezos_interop/webpack.config.js
+++ b/tezos_interop/webpack.config.js
@@ -1,7 +1,10 @@
 module.exports = env => ({
-  entry: ['./run_entrypoint.js'],
+  entry: {
+    run_entrypoint: './run_entrypoint.js',
+    listen_transactions: "./listen_transactions.js"
+  },
   output: {
-    filename: 'run_entrypoint.bundle.js',
+    filename: '[name].bundle.js',
     path: __dirname,
   },
   mode: env.dev ? 'development' : 'production',


### PR DESCRIPTION
## Problem

To achieve automatic deposit detection required by #34 we need to listen for operations on Tezos.

## Solution

This is a step on that direction, as Tezos doesn't provide a socket like API and I don't want to reimplement the polling logic already present in Taquito we just use Taquito to make a CLI, this CLI will accept the context on the `stdin` and each line on `stdout` is a transaction.

## Additional Problem

Operation hash is not enough to index a Tezos operation as the internals operations share the same hash, that's why I also include an index based on the operation result, as this should be reliable(result hash is checked by tezos) we can trust it to be in order and all nodes to agree on the index.

## Related

- #34 
- #61 