### PR TITLE
create state.bin when not present

### DIFF
--- a/bin/files.re
+++ b/bin/files.re
@@ -71,3 +71,10 @@ module Interop_context = {
   let read = read_json(of_yojson);
   let write = write_json(to_yojson);
 };
+
+module State_bin = {
+  let read = (~file) =>
+    Lwt_io.with_file(~mode=Input, file, Lwt_io.read_value);
+  let write = (protocol, ~file) =>
+    Lwt_io.with_file(~mode=Output, file, Lwt_io.write_value(_, protocol));
+};

--- a/bin/files.rei
+++ b/bin/files.rei
@@ -8,7 +8,6 @@ module Identity: {
   let read: (~file: string) => Lwt.t(identity);
   let write: (identity, ~file: string) => Lwt.t(unit);
 };
-
 module Wallet: {
   type t = {
     address: Wallet.t,
@@ -17,7 +16,6 @@ module Wallet: {
   let read: (~file: string) => Lwt.t(t);
   let write: (t, ~file: string) => Lwt.t(unit);
 };
-
 module Validators: {
   let read: (~file: string) => Lwt.t(list((Address.t, Uri.t)));
   let write: (list((Address.t, Uri.t)), ~file: string) => Lwt.t(unit);
@@ -25,4 +23,9 @@ module Validators: {
 module Interop_context: {
   let read: (~file: string) => Lwt.t(Tezos_interop.Context.t);
   let write: (Tezos_interop.Context.t, ~file: string) => Lwt.t(unit);
+};
+
+module State_bin: {
+  let read: (~file: string) => Lwt.t(Protocol.t);
+  let write: (Protocol.t, ~file: string) => Lwt.t(unit);
 };

--- a/bin/http_server.re
+++ b/bin/http_server.re
@@ -214,14 +214,12 @@ let node = {
   };
   let state_bin = folder ++ "/state.bin";
   let.await state_bin_exists = Lwt_unix.file_exists(state_bin);
-  let protocol =
+  let.await protocol =
     if (state_bin_exists) {
-      let ic = open_in_bin(state_bin);
-      let protocol = Marshal.from_channel(ic);
-      close_in(ic);
-      protocol;
+      Files.State_bin.read(~file=state_bin);
     } else {
-      node.protocol;
+      let.await () = Files.State_bin.write(node.protocol, ~file=state_bin);
+      await(node.protocol);
     };
   await({...node, protocol});
 };


### PR DESCRIPTION
## Problem

To produce-blocks a state.bin is required, but to start the chain you need to produce a block, so currently there is no way to start a fresh chain.

## Solution

When starting a node we always ensure there is a state.bin present, if there is none one is created with a state with the genesis state.

## Related

- Closes #121