### PR TITLE
use b58 to represent Address.key

### DIFF
--- a/protocol/address.re
+++ b/protocol/address.re
@@ -1,3 +1,4 @@
+open Helpers;
 open Mirage_crypto_ec;
 
 type key = Ed25519.priv;
@@ -8,21 +9,15 @@ let to_hex = str => {
   str;
 };
 let of_hex = hex => Hex.to_string(`Hex(hex));
-let key_to_yojson = t =>
-  `String(Ed25519.priv_to_cstruct(t) |> Cstruct.to_string |> to_hex);
-let key_of_yojson =
-  fun
-  | `String(key) =>
-    // TODO: this raises an exception
-    try(
-      of_hex(key)
-      |> Cstruct.of_string
-      |> Ed25519.priv_of_cstruct
-      |> Result.map_error(Format.asprintf("%a", Mirage_crypto_ec.pp_error))
-    ) {
-    | _ => Error("failed to parse")
-    }
-  | _ => Error("invalid type");
+let key_to_yojson = key =>
+  `String(Tezos_interop.Secret.to_string(Ed25519(key)));
+let key_of_yojson = json => {
+  let.ok string = [%of_yojson: string](json);
+  let.ok Ed25519(key) =
+    Tezos_interop.Secret.of_string(string)
+    |> Option.to_result(~none="failed to parse");
+  ok(key);
+};
 
 type t = Ed25519.pub_; // TODO: is okay to have this public
 
@@ -50,7 +45,7 @@ let of_yojson =
 
 let of_key = Ed25519.pub_of_priv;
 
-let genesis_key = {|fdc6199df66d421df1496785497b3974b36862beac7c543a9c77b99ccf168f02|};
+let genesis_key = {|edsk4bfbFdb4s2BdkW3ipfB23i9u82fgji6KT3oj2SCWTeHUthbSVd|};
 let genesis_key =
   switch (key_of_yojson(`String(genesis_key))) {
   | Ok(key) => key


### PR DESCRIPTION
## Problem

Currently we're using b58 to represent Tezos secret but just hex encoding to represent Address.key which means for the same thing, an ed25519 secret key we have two encodings.

## Solution

Move everything to b58 as it is a well established standard. Here the prefix is `edpk`.

## Migration

```reason
Tezos_interop.Base58.(
  simple_encode(
    ~prefix=Prefix.ed25519_seed,
    ~to_raw=Fun.id,
    Hex.to_string(`Hex("key_hex_here")),
  )
)
```