### PR TITLE
support Operation_hash on Tezos_interop

### DIFF
--- a/tests/test_tezos_interop.re
+++ b/tests/test_tezos_interop.re
@@ -278,6 +278,45 @@ describe("ticket", ({test, _}) => {
       toBeNone()
   });
 });
+describe("operation_hash", ({test, _}) => {
+  open Operation_hash;
+
+  let op =
+    of_string("opCAkifFMh1Ya2J4WhRHskaXc297ELtx32wnc2WzeNtdQHp7DW4")
+    |> Option.get;
+  test("to_string", ({expect, _}) => {
+    expect.string(to_string(op)).toEqual(
+      "opCAkifFMh1Ya2J4WhRHskaXc297ELtx32wnc2WzeNtdQHp7DW4",
+    )
+  });
+  test("of_string", ({expect, _}) => {
+    expect.option(
+      of_string({|opCAkifFMh1Ya2J4WhRHskaXc297ELtx32wnc2WzeNtdQHp7DW4|}),
+    ).
+      toBe(
+      ~equals=(==),
+      Some(op),
+    )
+  });
+  test("invalid prefix", ({expect, _}) => {
+    expect.option(
+      of_string("obCAkifFMh1Ya2J4WhRHskaXc297ELtx32wnc2WzeNtdQHp7DW4"),
+    ).
+      toBeNone()
+  });
+  test("invalid checksum", ({expect, _}) => {
+    expect.option(
+      of_string("opCAkifFMh1Ya2J4WhRHskaXc297ELtx32wnc2WzeNtdQHp7DW5"),
+    ).
+      toBeNone()
+  });
+  test("invalid size", ({expect, _}) => {
+    expect.option(
+      of_string("opCAkifFMh1Ya2J4WhRHskaXc297ELtx32wnc2WzeNtdQHp7DW"),
+    ).
+      toBeNone()
+  });
+});
 describe("pack", ({test, _}) => {
   open Pack;
 

--- a/tezos_interop/base58.ml
+++ b/tezos_interop/base58.ml
@@ -30,6 +30,7 @@ module Prefix = struct
   let ed25519_public_key_hash = "\006\161\159" (* tz1(36) *)
 
   (* 32 *)
+  let operation_hash = "\005\116" (* o(51) *)
   let ed25519_public_key = "\013\015\037\217" (* edpk(54) *)
   let ed25519_seed = "\013\015\058\007" (* edsk(54) *)
 

--- a/tezos_interop/base58.mli
+++ b/tezos_interop/base58.mli
@@ -29,6 +29,8 @@
 module Prefix : sig
   val contract_hash : string
 
+  val operation_hash : string
+
   val ed25519_public_key_hash : string
 
   val ed25519_public_key : string

--- a/tezos_interop/tezos_interop.re
+++ b/tezos_interop/tezos_interop.re
@@ -353,6 +353,16 @@ module Ticket = {
   };
 };
 
+module Operation_hash = {
+  type t = BLAKE2B.t;
+
+  let prefix = Base58.Prefix.operation_hash;
+  let to_raw = BLAKE2B.to_raw_string;
+  let of_raw = BLAKE2B.of_raw_string;
+  let to_string = t => Base58.simple_encode(~prefix, ~to_raw, t);
+  let of_string = string => Base58.simple_decode(~prefix, ~of_raw, string);
+};
+
 module Pack = {
   open Tezos_micheline;
   open Micheline;

--- a/tezos_interop/tezos_interop.rei
+++ b/tezos_interop/tezos_interop.rei
@@ -69,6 +69,14 @@ module Ticket: {
   let to_string: t => string;
   let of_string: string => option(t);
 };
+
+module Operation_hash: {
+  type t = BLAKE2B.t;
+
+  let to_string: t => string;
+  let of_string: string => option(t);
+};
+
 module Pack: {
   type t;
 


### PR DESCRIPTION
## Problem

To index Tezos operations we use the Tezos index, but as we use taquito to download data at #120 the hashes come as a string which need then to be converted to a BLAKE2B.

## Solution

This adds direct support to Operation_hash on Tezos_interop as a `BLAKE2B.t`.

## Related

- #34 
- #61 
