### PR TITLE
refactor main chain operations

### DIFF
--- a/protocol/operation.rei
+++ b/protocol/operation.rei
@@ -15,11 +15,27 @@ module Main_chain: {
   [@deriving (ord, yojson)]
   type t =
     pri {
-      tezos_hash: BLAKE2B.t,
+      hash: BLAKE2B.t,
+      tezos_hash: Tezos_interop.Operation_hash.t,
+      tezos_index: int,
       kind,
     };
 
-  let make: (~tezos_hash: BLAKE2B.t, ~kind: kind) => t;
+  let make:
+    (
+      ~tezos_hash: Tezos_interop.Operation_hash.t,
+      ~tezos_index: int,
+      ~kind: kind
+    ) =>
+    t;
+  let verify:
+    (
+      ~hash: BLAKE2B.t,
+      ~tezos_hash: Tezos_interop.Operation_hash.t,
+      ~tezos_index: int,
+      ~kind: kind
+    ) =>
+    result(t, string);
 };
 
 module Side_chain: {

--- a/tests/test_protocol.re
+++ b/tests/test_protocol.re
@@ -136,7 +136,11 @@ describe("protocol state", ({test, _}) => {
     expect.list(Validators.to_list(validators)).toBeEmpty();
     let new_validator = Validators.{address: Address.make_pubkey()};
     let main_op = kind =>
-      Operation.Main_chain.make(~tezos_hash=Helpers.BLAKE2B.hash(""), ~kind);
+      Operation.Main_chain.make(
+        ~tezos_hash=Helpers.BLAKE2B.hash(""),
+        ~tezos_index=0,
+        ~kind,
+      );
     let state =
       apply_main_chain(state, main_op(Add_validator(new_validator)));
     let validators = state.validators;


### PR DESCRIPTION
## Problem

At #120 we found out that main chain operations require more than just a tezos_hash, but also a tezos_index, which is currently not implemented and is required to future integrations.

## Solution

This refactors the main chain operation to include a tezos_index but also adds a hashing so that in the future integration we can verify if the main chain operation is known easily.