### PR TITLE
 add Consensus.listen_operations on Tezos_interop

### DIFF
--- a/tezos_interop/tezos_interop.rei
+++ b/tezos_interop/tezos_interop.rei
@@ -136,6 +136,21 @@ module Consensus: {
       ~signatures: list((Key.t, option(Signature.t)))
     ) =>
     Lwt.t(unit);
+
+  type parameters =
+    | Deposit({
+        ticket: Ticket.t,
+        // TODO: proper type for amounts
+        amount: Z.t,
+        destination: Address.t,
+      });
+  type operation = {
+    hash: Operation_hash.t,
+    index: int,
+    parameters,
+  };
+  let listen_operations:
+    (~context: Context.t, ~on_operation: operation => unit) => unit;
 };
 
 module Discovery: {let sign: (Secret.t, ~nonce: int64, Uri.t) => Signature.t;};


### PR DESCRIPTION
## Depends

- [x] #132 

## Problem

To achieve #34 and #61 we need to be able to listen to deposit operations that happens on Tezos.

## Solution

This is a step on this direction, by integrating Tezos_interop on the `listen_transactions.js` script added on #120. We can in the future use this function to 
 detect operations happening Tezos.
 
 ## Related
 
 - #34 
 - #61 
