### PR TITLE
Defend against unknown main operation

### DIFF
--- a/node/building_blocks.re
+++ b/node/building_blocks.re
@@ -57,11 +57,18 @@ let is_current_producer = (state, ~key) => {
 
 // TODO: bad naming
 // TODO: check if block must have published a new snapshot
-let is_signable = (state, block) =>
+let is_signable = (state, block) => {
+  // TODO: this is O(n*m) which is bad
+  let is_known_main = main_op =>
+    state.State.pending_main_ops |> List.exists(op => op == main_op);
+  let all_main_ops_are_known =
+    List.for_all(is_known_main, block.Block.main_chain_ops);
   is_next(state, block)
   && !is_signed_by_self(state, ~hash=block.hash)
   && is_current_producer(state, ~key=block.author)
-  && !has_next_block_to_apply(state, ~hash=block.hash);
+  && !has_next_block_to_apply(state, ~hash=block.hash)
+  && all_main_ops_are_known;
+};
 
 let sign = (~key, block) => Block.sign(~key, block);
 


### PR DESCRIPTION
## Depends

- [x] #134 

## Problem

Because of the protocol was designed originally on the assumption that all main chain operations were confirmed, currently the block producer can include an operation and we will never verify it.

## Solution

Instead of verifying it, as the integration with Tezos is not reliable, we just avoid signing a block if it includes an unknown main operation. That means if 2/3 of the chain signs, it will still be applied but a validator will never signs an unknown main operation.