### PR TITLE
Prevent replay attack on main operations

### DIFF
--- a/node/state.re
+++ b/node/state.re
@@ -199,6 +199,7 @@ let load_snapshot =
     (
       Ledger.t,
       Operation_side_chain_set.t,
+      Operation_main_chain_set.t,
       Validators.t,
       BLAKE2B.t,
       int64,
@@ -209,6 +210,7 @@ let load_snapshot =
   let (
     ledger,
     included_operations,
+    included_main_operations,
     validators,
     validators_hash,
     block_height,
@@ -224,6 +226,7 @@ let load_snapshot =
     Protocol.{
       ledger,
       included_operations,
+      included_main_operations,
       validators,
       validators_hash,
       block_height,

--- a/protocol/state.re
+++ b/protocol/state.re
@@ -1,6 +1,7 @@
 open Helpers;
 
 module Operation_side_chain_set = Set_with_yojson_make(Operation.Side_chain);
+module Operation_main_chain_set = Set_with_yojson_make(Operation.Main_chain);
 
 type t = {
   // state machine data
@@ -8,6 +9,7 @@ type t = {
   // TODO: more efficient lookup on included_operations
   // TODO: is this part of the protocol?
   included_operations: Operation_side_chain_set.t,
+  included_main_operations: Operation_main_chain_set.t,
   // consensus
   validators: Validators.t,
   validators_hash: BLAKE2B.t,
@@ -29,6 +31,7 @@ let hash = t => {
     (
       Ledger.t,
       Operation_side_chain_set.t,
+      Operation_main_chain_set.t,
       Validators.t,
       BLAKE2B.t,
       int64,
@@ -40,6 +43,7 @@ let hash = t => {
     to_yojson((
       t.ledger,
       t.included_operations,
+      t.included_main_operations,
       t.validators,
       t.validators_hash,
       t.block_height,

--- a/tests/test_protocol.re
+++ b/tests/test_protocol.re
@@ -135,12 +135,17 @@ describe("protocol state", ({test, _}) => {
     expect.option(Validators.current(validators)).toBeNone();
     expect.list(Validators.to_list(validators)).toBeEmpty();
     let new_validator = Validators.{address: Address.make_pubkey()};
-    let main_op = kind =>
-      Operation.Main_chain.make(
-        ~tezos_hash=Helpers.BLAKE2B.hash(""),
-        ~tezos_index=0,
-        ~kind,
-      );
+    let main_op = {
+      let accu = ref(0);
+      kind => {
+        incr(accu);
+        Operation.Main_chain.make(
+          ~tezos_hash=Helpers.BLAKE2B.hash(""),
+          ~tezos_index=accu^,
+          ~kind,
+        );
+      };
+    };
     let state =
       apply_main_chain(state, main_op(Add_validator(new_validator)));
     let validators = state.validators;


### PR DESCRIPTION
## Depends

- [x] #135 

## Problem

Currently an operation can be added two times in a block and it will be applied, this is not the desirable as it allows to multiply money.

## Solution

Do the same as for Operation.Side_chain, have a list of included main operations on the protocol state. The only difference is that this will never be cleaned as there is no such a thing as a maximum block_height on main operations.