### PR TITLE
properly clean operations after applying block

### DIFF
--- a/node/building_blocks.re
+++ b/node/building_blocks.re
@@ -114,15 +114,15 @@ let apply_block = (state, update_state, block) => {
 
 let clean = (state, update_state, block) => {
   // TODO: this is the dumbest piece of code that I could write
-  let main_is_in_block = side_op =>
-    block.Block.main_chain_ops |> List.exists(op => side_op == op);
-  let side_is_in_block = side_op =>
-    block.side_chain_ops |> List.exists(op => side_op == op);
-
+  //       but now it should work
+  let main_op_not_in_block = main_op =>
+    !List.mem(main_op, block.Block.main_chain_ops);
+  let side_op_not_in_block = side_op =>
+    !List.mem(side_op, block.side_chain_ops);
   let pending_main_ops =
-    state.Node.pending_main_ops |> List.filter(main_is_in_block);
+    state.Node.pending_main_ops |> List.find_all(main_op_not_in_block);
   let pending_side_ops =
-    state.pending_side_ops |> List.filter(side_is_in_block);
+    state.pending_side_ops |> List.find_all(side_op_not_in_block);
   // TODO: clean old blocks and old signatures
   update_state({...state, pending_main_ops, pending_side_ops});
 };


### PR DESCRIPTION
## Depends

To keep the PR graph simple

- [x] #137 

## Problem

There is a bug on the cleaning logic where all operations that are in the block are kept on the pool, but all other operations are removed, the opposite should happen.

## Solution

Fix the bug and refactor a bit this block, it's still is bad but now it does the right thing.