### PR TITLE
add self subcommand

### DIFF
--- a/bin/sidecli.re
+++ b/bin/sidecli.re
@@ -589,6 +589,31 @@ let show_help = {
   );
 };
 
+let info_self = {
+  let doc = "Shows identity key and address of the node.";
+  Term.info("self", ~version="%‌%VERSION%%", ~doc, ~exits, ~man);
+};
+let self = folder => {
+  let file = folder ++ "/identity.json";
+  let.await identity = Files.Identity.read(~file);
+  Format.printf("key: %s\n", Address.to_string(identity.t));
+  Format.printf(
+    "address: %s\n",
+    Wallet.(of_address(identity.t) |> address_to_string),
+  );
+  Format.printf("uri: %s\n", Uri.to_string(identity.uri));
+  await(`Ok());
+};
+let self = {
+  let folder_dest = {
+    let docv = "folder_dest";
+    let doc = "The folder of the node.";
+    Arg.(required & pos(0, some(string), None) & info([], ~doc, ~docv));
+  };
+
+  Term.(lwt_ret(const(self) $ folder_dest));
+};
+
 // Run the CLI
 
 let () = {
@@ -604,6 +629,7 @@ let () = {
       (setup_identity, info_setup_identity),
       (setup_tezos, info_setup_tezos),
       (setup_node, info_setup_node),
+      (self, info_self),
     ],
   );
 };

--- a/protocol/address.re
+++ b/protocol/address.re
@@ -22,13 +22,16 @@ let make_pubkey = () => {
 
 let compare = (a, b) =>
   Cstruct.compare(Ed25519.pub_to_cstruct(a), Ed25519.pub_to_cstruct(b));
-let to_yojson = t => `String(Tezos_interop.Key.to_string(Ed25519(t)));
+let to_string = t => Tezos_interop.Key.to_string(Ed25519(t));
+let of_string = string => {
+  let.some Ed25519(t) = Tezos_interop.Key.of_string(string);
+  Some(t);
+};
+
+let to_yojson = t => `String(to_string(t));
 let of_yojson = json => {
   let.ok string = [%of_yojson: string](json);
-  let.ok Ed25519(t) =
-    Tezos_interop.Key.of_string(string)
-    |> Option.to_result(~none="failed to parse");
-  ok(t);
+  of_string(string) |> Option.to_result(~none="failed to parse");
 };
 
 let of_key = Ed25519.pub_of_priv;

--- a/protocol/address.rei
+++ b/protocol/address.rei
@@ -12,3 +12,6 @@ let genesis_key: key;
 let genesis_address: t;
 
 let make_pubkey: unit => t;
+
+let to_string: t => string;
+let of_string: string => option(t);


### PR DESCRIPTION
## Problem

Currently the only way to verify your identity is by checking inside of the `identity.json` but this is an implementation detail and should not be relied upon.

## Solution

This PR implements a `self` command that will print your key, address and uri so that we can easily awk it and be a bit more future proof.