### PR TITLE
ticket balance endpoint

### DIFF
--- a/bin/http_server.re
+++ b/bin/http_server.re
@@ -165,7 +165,15 @@ let handle_receive_operation_gossip =
       Ok();
     },
   );
-
+let handle_ticket_balance =
+  handle_request(
+    (module Ticket_balance),
+    (_update_state, {ticket, address}) => {
+      let state = Server.get_state();
+      let amount = Flows.request_ticket_balance(state, ~ticket, ~address);
+      Ok({amount: amount});
+    },
+  );
 let node = {
   let folder = Sys.argv[1];
   let.await identity = Files.Identity.read(~file=folder ++ "/identity.json");
@@ -237,6 +245,7 @@ let _server =
   |> handle_request_nonce
   |> handle_register_uri
   |> handle_receive_operation_gossip
+  |> handle_ticket_balance
   |> App.start
   |> Lwt_main.run;
 

--- a/node/flows.re
+++ b/node/flows.re
@@ -387,3 +387,6 @@ let register_uri = (state, update_state, ~uri, ~signature) => {
     });
   Ok();
 };
+
+let request_ticket_balance = (state, ~ticket, ~address) =>
+  state.Node.protocol.ledger |> Ledger.balance(address, ticket);

--- a/node/networking.re
+++ b/node/networking.re
@@ -157,6 +157,17 @@ module Operation_gossip = {
   let path = "/operation-gossip";
 };
 
+module Ticket_balance = {
+  [@deriving yojson]
+  type request = {
+    address: Wallet.t,
+    ticket: Ticket.t,
+  };
+  [@deriving yojson]
+  type response = {amount: Amount.t};
+  let path = "/ticket-balance";
+};
+
 let request_block_by_hash = request((module Block_by_hash_spec));
 let request_block_level = request((module Block_level));
 let request_protocol_snapshot = request((module Protocol_snapshot));

--- a/protocol/protocol.re
+++ b/protocol/protocol.re
@@ -6,6 +6,7 @@ module Signature = Signature;
 module Address = Address;
 module Wallet = Wallet;
 module Ledger = Ledger;
+module Ticket = Ticket;
 module Validators = Validators;
 module Amount = Amount;
 module Block = Block;


### PR DESCRIPTION
## Depends

- [x] #148 

## Problem

Currently we do not provide a way to check balance of an address, so the only way to know if there is balance available is to make a transaction from the address.

## Solution

Implement an endpoint to check the ticket balance based on the ticket id.

## How to test

```json
POST /ticket-balance
{
    "address": "tz1NJ8q6qunwi2Thx4MxtVtMXixTtcJcXL5q",
    "ticket": {
        "ticketer": "KT199KwMHcpnmroMMYWwKUtZz2fygX18yDYz",
        "data": ""
    }
}
``` 