### PR TITLE
fix the validators ordering

### DIFF
--- a/bin/http_server.re
+++ b/bin/http_server.re
@@ -200,10 +200,11 @@ let node = {
     protocol: {
       ...node.protocol,
       validators:
-        List.fold_right(
-          ((address, _)) => Validators.add({address: address}),
-          validators,
+        List.fold_left(
+          (validators, (address, _)) =>
+            Validators.add({address: address}, validators),
           Validators.empty,
+          validators,
         ),
     },
   };


### PR DESCRIPTION
## Depends

- [ ] #152 

## Problem

Currently the validators order loaded in the node is reversed of the `validators.json`, but the order matters to the Tezos contract.

## Solution

Fix the ordering on the load, in the future this will be done different as per @callistonianembrace work.