### PR TITLE
Adds a Taquito script to fetch contract storage

### DIFF
--- a/tezos_interop/dune
+++ b/tezos_interop/dune
@@ -5,11 +5,19 @@
   (pps ppx_deriving_yojson ppx_blob))
  (preprocessor_deps
   (file ./run_entrypoint.bundle.js)
+  (file ./fetch_storage.bundle.js)
   (file ./listen_transactions.bundle.js)))
 
 (rule
- (deps ./webpack.config.js ./listen_transactions.js ./run_entrypoint.js)
- (targets ./listen_transactions.bundle.js ./run_entrypoint.bundle.js)
+ (deps
+  ./webpack.config.js
+  ./listen_transactions.js
+  ./fetch_storage.js
+  ./run_entrypoint.js)
+ (targets
+  ./listen_transactions.bundle.js
+  ./fetch_storage.bundle.js
+  ./run_entrypoint.bundle.js)
  (mode fallback)
  (action
   (run webpack --env=%{profile})))

--- a/tezos_interop/fetch_storage.js
+++ b/tezos_interop/fetch_storage.js
@@ -1,0 +1,64 @@
+"use strict";
+
+const fs = require("fs");
+const taquito = require("@taquito/taquito");
+const { RpcClient } = require("@taquito/rpc");
+const { InMemorySigner } = require("@taquito/signer");
+
+const { TezosToolkit } = taquito;
+/**
+ * @typedef Input
+ * @type {object}
+ * @property {string} contract_address
+ * @property {number} confirmation
+ * @property {string} rpc_node
+ */
+/** @returns {Input} */
+const input = () => JSON.parse(fs.readFileSync(process.stdin.fd));
+
+/**
+ * @typedef OutputFinished
+ * @type {object}
+ * @property {"success"} status
+ * @property {rpc.MichelsonV1Expression} storage
+ */
+/**
+ * @typedef OutputError
+ * @type {object}
+ * @property {"error"} status
+ * @property {string} error
+ */
+/** @param {OutputFinished | OutputError} data */
+const output = (data) =>
+  fs.writeFileSync(process.stdout.fd, JSON.stringify(data, null, 2));
+
+const finished = (storage) => output({ status: "success", storage });
+const error = (error) =>
+  output({ status: "error", error: JSON.stringify(error) });
+
+(async () => {
+  const { rpc_node, contract_address, confirmation } = input();
+  const client = new RpcClient(rpc_node);
+  const Tezos = new TezosToolkit(rpc_node);
+  const block = await client.getBlock(); // fetches the head
+  const contract = await client.getContract(contract_address, {
+    block: block.hash,
+  });
+  const storage = contract.script.storage;
+  /* To make sure the storage state is finalized, we query the last
+     block and any one of it's operation, and wait till it receives
+     `n` confirmations (where n is the minimum blocks needs to
+     consider reorg highly unlikely. ie finality) */
+  const operationFromHead = block.operations.flat()[0];
+  if (operationFromHead) {
+    const operation = await Tezos.operation.createTransactionOperation(
+      operationFromHead.hash
+    );
+    const result = await operation.confirmation(confirmation);
+    if (await result.isInCurrentBranch()) {
+      finished(storage);
+    } else {
+      error({ message: "Not in current Branch" });
+    }
+  }
+})().catch(error);

--- a/tezos_interop/listen_transactions.js
+++ b/tezos_interop/listen_transactions.js
@@ -47,8 +47,10 @@ operationStream.on("error", error);
 operationStream.on("data", async (content) => {
   /** @type {rpc.OperationContentsAndResultMetadataTransaction} */
   const metadata = content.metadata;
-  if (content.kind !== taquito.OpKind.TRANSACTION
-    || metadata.operation_result.status !== "applied") {
+  if (
+    content.kind !== taquito.OpKind.TRANSACTION ||
+    metadata.operation_result.status !== "applied"
+  ) {
     return;
   }
   try {

--- a/tezos_interop/run_entrypoint.js
+++ b/tezos_interop/run_entrypoint.js
@@ -38,8 +38,14 @@ const error = (error) =>
   output({ status: "error", error: JSON.stringify(error) });
 
 (async () => {
-  const { rpc_node, secret, confirmation, destination, entrypoint, payload } =
-    input();
+  const {
+    rpc_node,
+    secret,
+    confirmation,
+    destination,
+    entrypoint,
+    payload,
+  } = input();
   const args = Object.entries(payload)
     .sort(([a], [b]) => a.localeCompare(b))
     .map(([_, value]) => value);

--- a/tezos_interop/webpack.config.js
+++ b/tezos_interop/webpack.config.js
@@ -1,12 +1,13 @@
-module.exports = env => ({
+module.exports = (env) => ({
   entry: {
-    run_entrypoint: './run_entrypoint.js',
-    listen_transactions: "./listen_transactions.js"
+    run_entrypoint: "./run_entrypoint.js",
+    fetch_storage: "./fetch_storage.js",
+    listen_transactions: "./listen_transactions.js",
   },
   output: {
-    filename: '[name].bundle.js',
+    filename: "[name].bundle.js",
     path: __dirname,
   },
-  mode: env.dev ? 'development' : 'production',
-  target: 'node'
+  mode: env.dev ? "development" : "production",
+  target: "node",
 });


### PR DESCRIPTION
## Problem

We manually generate validators.json with sh scripts on the client, where as the deployed `consensus.mligo` should be the source of truth.

## Solution

This PR adds a Taquito script that inspects a contracts storage.  `module Fetch_storage` that fetches the storage and return it as michelson.