### PR TITLE
Fetch validators from consensus contract

### DIFF
--- a/tezos_interop/fetch_storage.js
+++ b/tezos_interop/fetch_storage.js
@@ -60,5 +60,7 @@ const error = (error) =>
     } else {
       error({ message: "Not in current Branch" });
     }
+  } else {
+    error({ message: "Internal error: operationFromHead was undefined" });
   }
 })().catch(error);

--- a/tezos_interop/tezos_interop.rei
+++ b/tezos_interop/tezos_interop.rei
@@ -1,5 +1,4 @@
 open Helpers;
-
 module Base58 = Base58;
 
 module Key: {
@@ -102,6 +101,7 @@ module Context: {
     required_confirmations: int,
   };
 };
+
 module Consensus: {
   let hash_validators: list(Key.t) => BLAKE2B.t;
   let hash_block:
@@ -151,6 +151,8 @@ module Consensus: {
   };
   let listen_operations:
     (~context: Context.t, ~on_operation: operation => unit) => unit;
+  let fetch_validators:
+    (~context: Context.t) => Lwt.t(result(list(Key.t), string));
 };
 
 module Discovery: {let sign: (Secret.t, ~nonce: int64, Uri.t) => Signature.t;};


### PR DESCRIPTION
## Depends
- [x] #157 

## Problem
We manually generate validators.json with sh scripts on the client, where as the deployed `consensus.mligo` should be the source of truth.

## Solution
This PR uses the Taquito script from #157 to fetch the validators set