### PR TITLE
add CLI withdraw command

### DIFF
--- a/bin/http_server.re
+++ b/bin/http_server.re
@@ -1,7 +1,3 @@
-/*
-
- */
-
 // TODO: does computers have multiple RTC nowadays?
 // Can a core send a message and the other receive it in the past?
 // TODO: should start signing before being in sync?


### PR DESCRIPTION
## Problem

We need a simple way to trigger withdraws on the sidechain so that they can be used in the future to construct a proof and be withdraw on Tezos.

## Solution

This commands implements the withdraw command in a similar manner to `create-transaction`

## Usage

```sh
## This will withdraw from the wallet.json to tz1QTt4YksnwfDnvu7eFGWdEu7gEyZgnc3Vk on Tezos

esy x sidecli withdraw data/0 ./wallet.json "tz1QTt4YksnwfDnvu7eFGWdEu7gEyZgnc3Vk" 32 'Pair "KT199KwMHcpnmroMMYWwKUtZz2fygX18yDYz" 0x'
```

## Related

- #164 