### PR TITLE
store operation results temporarily

### DIFF
--- a/helpers/BLAKE2B.re
+++ b/helpers/BLAKE2B.re
@@ -18,6 +18,8 @@ module Make =
          let verify: (~hash: t, string) => bool;
 
          let both: (t, t) => t;
+
+         module Map: Map.S with type key = t;
        } => {
   include P;
   include Digestif.Make_BLAKE2B({
@@ -42,6 +44,12 @@ module Make =
   let verify = (~hash as expected_hash, data) => expected_hash == hash(data);
 
   let both = (a, b) => hash(to_raw_string(a) ++ to_raw_string(b));
+
+  module Map =
+    Map.Make({
+      type nonrec t = t;
+      let compare = compare;
+    });
 };
 
 module BLAKE2B_20 =

--- a/node/state.re
+++ b/node/state.re
@@ -106,7 +106,8 @@ let try_to_commit_state_hash = (~old_state, state, block, signatures) => {
 };
 let apply_block = (state, block) => {
   let old_state = state;
-  let.ok (protocol, new_snapshot) = apply_block(state.protocol, block);
+  let.ok (protocol, new_snapshot, _result) =
+    apply_block(state.protocol, block);
   let state = {...state, protocol};
   Lwt.async(() =>
     Lwt_io.with_file(
@@ -239,7 +240,9 @@ let load_snapshot =
     fold_left_ok(
       (protocol, block) => {
         // TODO: ignore this may be really bad for snapshots
-        let.ok (protocol, _new_hash) = Protocol.apply_block(protocol, block);
+        // TODO: ignore the result is also really bad
+        let.ok (protocol, _new_hash, _result) =
+          Protocol.apply_block(protocol, block);
         Ok(protocol);
       },
       protocol,

--- a/node/state.rei
+++ b/node/state.rei
@@ -22,6 +22,8 @@ type t = {
   // networking
   uri_state: Uri_map.t(string),
   validators_uri: Address_map.t(Uri.t),
+  recent_operation_results:
+    BLAKE2B.Map.t([ | `Transaction | `Withdraw(Ledger.Handle.t)]),
 };
 
 let make:

--- a/tests/test_protocol.re
+++ b/tests/test_protocol.re
@@ -98,36 +98,43 @@ describe("protocol state", ({test, _}) => {
     ~free_diff_a=-7,
     ~free_diff_b=7,
     (state, (source, secret), (destination, _)) => {
-    apply_side_chain(
-      state,
-      Operation.Side_chain.sign(
-        ~secret,
-        ~nonce=0l,
-        ~block_height=0L,
-        ~source,
-        ~amount=Amount.of_int(7),
-        ~ticket,
-        ~kind=Transaction({destination: destination}),
-      ),
-    )
-  });
+      let (state, result) =
+        apply_side_chain(
+          state,
+          Operation.Side_chain.sign(
+            ~secret,
+            ~nonce=0l,
+            ~block_height=0L,
+            ~source,
+            ~amount=Amount.of_int(7),
+            ~ticket,
+            ~kind=Transaction({destination: destination}),
+          ),
+        );
+      assert(result == `Transaction);
+      state;
+    },
+  );
   test_failed_wallet_offset(
     "transaction",
     "not enough funds",
-    (state, (source, secret), (destination, _)) =>
-    apply_side_chain(
-      state,
-      Operation.Side_chain.sign(
-        ~secret,
-        ~nonce=0l,
-        ~block_height=0L,
-        ~source,
-        ~amount=Amount.of_int(501),
-        ~ticket,
-        ~kind=Transaction({destination: destination}),
-      ),
-    )
-  );
+    (state, (source, secret), (destination, _)) => {
+    let (state, result) =
+      apply_side_chain(
+        state,
+        Operation.Side_chain.sign(
+          ~secret,
+          ~nonce=0l,
+          ~block_height=0L,
+          ~source,
+          ~amount=Amount.of_int(501),
+          ~ticket,
+          ~kind=Transaction({destination: destination}),
+        ),
+      );
+    assert(result == `Transaction);
+    state;
+  });
   test("validators", ({expect, _}) => {
     // TODO: this clearly should be splitten and properly automated
     let (state, _, _) = make_state(~validators=Validators.empty, ());


### PR DESCRIPTION
## Problem

To achieve #164 we need to somehow get the handle for an operation, but this is only known after the operation is applied, which currently means the result of the operation is lost.

## Solution

In this PR we store it temporarily(during the node execution), so that it can be requested in a future PR from the operation hash.

## Related

- #164