### PR TITLE
add withdraw-proof command

### DIFF
--- a/bin/http_server.re
+++ b/bin/http_server.re
@@ -161,6 +161,12 @@ let handle_receive_operation_gossip =
       Ok();
     },
   );
+let handle_withdraw_proof =
+  handle_request((module Withdraw_proof), (_, {operation_hash}) =>
+    Ok(
+      Flows.request_withdraw_proof(Server.get_state(), ~hash=operation_hash),
+    )
+  );
 let handle_ticket_balance =
   handle_request(
     (module Ticket_balance),
@@ -242,6 +248,7 @@ let _server =
   |> handle_request_nonce
   |> handle_register_uri
   |> handle_receive_operation_gossip
+  |> handle_withdraw_proof
   |> handle_ticket_balance
   |> App.start
   |> Lwt_main.run;

--- a/node/networking.re
+++ b/node/networking.re
@@ -157,6 +157,22 @@ module Operation_gossip = {
   let path = "/operation-gossip";
 };
 
+module Withdraw_proof = {
+  [@deriving yojson]
+  type request = {operation_hash: BLAKE2B.t};
+
+  [@deriving yojson]
+  type response =
+    | Ok({
+        handles_hash: BLAKE2B.t,
+        handle: Ledger.Handle.t,
+        proof: list((BLAKE2B.t, BLAKE2B.t)),
+      })
+    | Unknown_operation
+    | Operation_is_not_a_withdraw;
+
+  let path = "/withdraw-proof";
+};
 module Ticket_balance = {
   [@deriving yojson]
   type request = {
@@ -173,6 +189,7 @@ let request_block_level = request((module Block_level));
 let request_protocol_snapshot = request((module Protocol_snapshot));
 let request_nonce = request((module Request_nonce));
 let request_register_uri = request((module Register_uri));
+let request_withdraw_proof = request((module Withdraw_proof));
 let broadcast_signature = broadcast_to_validators((module Signature_spec));
 let broadcast_block_and_signature =
   broadcast_to_validators((module Block_and_signature_spec));

--- a/protocol/ledger.re
+++ b/protocol/ledger.re
@@ -121,5 +121,12 @@ let withdraw = (~source, ~destination, amount, ticket, t) => {
   Ok((t, handle));
 };
 
-let handles_find_proof = (key, t) => Handle_tree.find(key, t.handles);
+let handles_find_proof = (handle, t) =>
+  switch (Handle_tree.find(handle.Handle.id, t.handles)) {
+  // TODO: enforce this unreachability on the type system
+  // the only way to have a Handle.t is to do a withdraw
+  | None => assert(false)
+  | Some((proof, _)) => proof
+  };
+let handles_find_proof_by_id = (key, t) => Handle_tree.find(key, t.handles);
 let handles_root_hash = t => Handle_tree.hash(t.handles);

--- a/protocol/ledger.rei
+++ b/protocol/ledger.rei
@@ -32,7 +32,8 @@ let withdraw:
   ) =>
   result((t, Handle.t), [> | `Not_enough_funds]);
 
+let handles_find_proof: (Handle.t, t) => list((BLAKE2B.t, BLAKE2B.t));
 // TODO: I don't like this API
-let handles_find_proof:
+let handles_find_proof_by_id:
   (int, t) => option((list((BLAKE2B.t, BLAKE2B.t)), Handle.t));
 let handles_root_hash: t => BLAKE2B.t;


### PR DESCRIPTION
## Problem

At #167 we provide a command to make tickets withdraw easily but there is no simple way to use this and actually withdraw the tickets on Tezos.

## Solution

Here we provide a command that will give you a piece of michelson to be sent to the `%withdraw` entrypoint on the consensus contract.

## Usage

```sh
## make the withdraw on the sidechain
esy x sidecli withdraw data/0 ./wallet.json "<OWNER>" <AMOUNT> 'Pair "<TICKETER>" 0x<DATA>'
## get the handle
HANDLE=$(esy x sidecli withdraw-proof data/0 <OPERATION_HASH> <CONTRACT_CALLBACK>)
## use the handle to withdraw on Tezos
tezos-client transfer 0 from <OWNER> to <CONSENSUS_CONTRACT> --entrypoint "withdraw" --arg "$HANDLE"
```

## Related

- Closes #164 