### PR TITLE
Parse `update_root_hash` operation  from the mainchain

### DIFF
--- a/tezos_interop/tezos_interop.rei
+++ b/tezos_interop/tezos_interop.rei
@@ -143,7 +143,8 @@ module Consensus: {
         // TODO: proper type for amounts
         amount: Z.t,
         destination: Address.t,
-      });
+      })
+    | Update_root_hash(BLAKE2B.t);
   type operation = {
     hash: Operation_hash.t,
     index: int,


### PR DESCRIPTION
## Problem

We don't have a way to know if the node is in sync with the mainchain

## Solution

This PR (along with #175 ), adds the ability to parse `update_root_hash` operations, so that updates to state root hash published to the main chain can be listened in, which would help a node know if it is in sync with main chain or not.