### PR TITLE
Removes unused mainchain_ops: add/remove validators

### DIFF
--- a/protocol/operation.re
+++ b/protocol/operation.re
@@ -5,8 +5,6 @@ module Main_chain = {
   type kind =
     // TODO: can a validator uses the same key in different nodes?
     // If so the ordering in the list must never use the same key two times in sequence
-    | Add_validator(Validators.validator)
-    | Remove_validator(Validators.validator)
     | Deposit({
         destination: Wallet.t,
         amount: Amount.t,

--- a/protocol/operation.rei
+++ b/protocol/operation.rei
@@ -4,8 +4,6 @@ module Main_chain: {
   type kind =
     // TODO: can a validator uses the same key in different nodes?
     // If so the ordering in the list must never use the same key two times in sequence
-    | Add_validator(Validators.validator)
-    | Remove_validator(Validators.validator)
     | Deposit({
         destination: Wallet.t,
         amount: Amount.t,

--- a/protocol/protocol.re
+++ b/protocol/protocol.re
@@ -25,12 +25,6 @@ let apply_main_chain = (state, operation) => {
   let state =
     switch (operation.kind) {
     // validators management
-    | Add_validator(validator) =>
-      let validators = Validators.add(validator, state.validators);
-      {...state, validators};
-    | Remove_validator(validator) =>
-      let validators = Validators.remove(validator, state.validators);
-      {...state, validators};
     | Deposit({destination, amount, ticket}) =>
       let ledger = Ledger.deposit(destination, amount, ticket, state.ledger);
       {...state, ledger};

--- a/tests/test_protocol.re
+++ b/tests/test_protocol.re
@@ -141,42 +141,6 @@ describe("protocol state", ({test, _}) => {
     let validators = state.validators;
     expect.option(Validators.current(validators)).toBeNone();
     expect.list(Validators.to_list(validators)).toBeEmpty();
-    let new_validator = Validators.{address: Address.make_pubkey()};
-    let main_op = {
-      let accu = ref(0);
-      kind => {
-        incr(accu);
-        Operation.Main_chain.make(
-          ~tezos_hash=Helpers.BLAKE2B.hash(""),
-          ~tezos_index=accu^,
-          ~kind,
-        );
-      };
-    };
-    let state =
-      apply_main_chain(state, main_op(Add_validator(new_validator)));
-    let validators = state.validators;
-    expect.bool(Validators.current(validators) == Some(new_validator)).
-      toBeTrue();
-    expect.list(Validators.to_list(validators)).toEqual([new_validator]);
-    // duplicated is a noop
-    let state =
-      apply_main_chain(state, main_op(Add_validator(new_validator)));
-    let validators = state.validators;
-    expect.bool(Validators.current(validators) == Some(new_validator)).
-      toBeTrue();
-    expect.list(Validators.to_list(validators)).toEqual([new_validator]);
-    // additional shouldn't move current
-    let another_validator = Validators.{address: Address.make_pubkey()};
-    let state =
-      apply_main_chain(state, main_op(Add_validator(another_validator)));
-    let validators = state.validators;
-    expect.bool(Validators.current(validators) == Some(new_validator)).
-      toBeTrue();
-    expect.list(Validators.to_list(validators)).toEqual([
-      new_validator,
-      another_validator,
-    ]);
     // next
     // let state = Protocol.next(state);
     // let validators = state.validators;
@@ -187,12 +151,6 @@ describe("protocol state", ({test, _}) => {
     //   another_validator,
     // ]);
     // remove current validator
-    let state =
-      apply_main_chain(state, main_op(Remove_validator(another_validator)));
-    let validators = state.validators;
-    expect.bool(Validators.current(validators) == Some(new_validator)).
-      toBeTrue();
-    expect.list(Validators.to_list(validators)).toEqual([new_validator]);
     // next
     // let state = Protocol.next(state);
     // let validators = state.validators;
@@ -200,11 +158,6 @@ describe("protocol state", ({test, _}) => {
     //   toBeTrue();
     // expect.list(Validators.validators(validators)).toEqual([new_validator]);
     // remove all validators
-    let state =
-      apply_main_chain(state, main_op(Remove_validator(new_validator)));
-    let validators = state.validators;
-    expect.option(Validators.current(validators)).toBeNone();
-    expect.list(Validators.to_list(validators)).toBeEmpty();
   });
   // TODO: check on of_yojson
   /*


### PR DESCRIPTION
## Problem

We have unused mainchain ops - Add_validator and Remove_validator

## Solution

This PR remove the said unused mainchain ops