### PR TITLE
Adds trusted_validators in the node-local state

### DIFF
--- a/bin/deku_node.re
+++ b/bin/deku_node.re
@@ -179,6 +179,14 @@ let handle_ticket_balance =
 let node = {
   let folder = Sys.argv[1];
   let.await identity = Files.Identity.read(~file=folder ++ "/identity.json");
+  let.await trusted_validator_membership_change_list =
+    Files.Trusted_validators_membership_change.read(
+      ~file=folder ++ "/trusted-validator-membership-change.json",
+    );
+  let trusted_validator_membership_change =
+    Trusted_validators_membership_change.Set.of_list(
+      trusted_validator_membership_change_list,
+    );
   let.await interop_context =
     Files.Interop_context.read(~file=folder ++ "/tezos.json");
   let.await validator_res =
@@ -207,6 +215,7 @@ let node = {
   let node =
     State.make(
       ~identity,
+      ~trusted_validator_membership_change,
       ~interop_context,
       ~data_folder=folder,
       ~initial_validators_uri,

--- a/bin/files.re
+++ b/bin/files.re
@@ -12,14 +12,17 @@ let read_json = (of_yojson, ~file) => {
   | Error(error) => raise(Invalid_json(error))
   };
 };
+
 let write_json = (to_yojson, data, ~file) =>
   Lwt_io.with_file(~mode=Output, file, oc =>
     Lwt_io.write(oc, Yojson.Safe.pretty_to_string(to_yojson(data)))
   );
+
 module Identity = {
   let read = read_json(identity_of_yojson);
   let write = write_json(identity_to_yojson);
 };
+
 module Wallet = {
   [@deriving yojson]
   type t = {
@@ -77,4 +80,12 @@ module State_bin = {
     Lwt_io.with_file(~mode=Input, file, Lwt_io.read_value);
   let write = (protocol, ~file) =>
     Lwt_io.with_file(~mode=Output, file, Lwt_io.write_value(_, protocol));
+};
+
+module Trusted_validators_membership_change = {
+  [@deriving yojson]
+  type t = Node.Trusted_validators_membership_change.t;
+
+  let read = read_json([%of_yojson: list(t)]);
+  let write = write_json([%to_yojson: list(t)]);
 };

--- a/bin/files.rei
+++ b/bin/files.rei
@@ -8,6 +8,7 @@ module Identity: {
   let read: (~file: string) => Lwt.t(identity);
   let write: (identity, ~file: string) => Lwt.t(unit);
 };
+
 module Wallet: {
   type t = {
     address: Wallet.t,
@@ -16,10 +17,12 @@ module Wallet: {
   let read: (~file: string) => Lwt.t(t);
   let write: (t, ~file: string) => Lwt.t(unit);
 };
+
 module Validators: {
   let read: (~file: string) => Lwt.t(list((Address.t, Uri.t)));
   let write: (list((Address.t, Uri.t)), ~file: string) => Lwt.t(unit);
 };
+
 module Interop_context: {
   let read: (~file: string) => Lwt.t(Tezos_interop.Context.t);
   let write: (Tezos_interop.Context.t, ~file: string) => Lwt.t(unit);
@@ -28,4 +31,12 @@ module Interop_context: {
 module State_bin: {
   let read: (~file: string) => Lwt.t(Protocol.t);
   let write: (Protocol.t, ~file: string) => Lwt.t(unit);
+};
+
+module Trusted_validators_membership_change: {
+  [@deriving yojson]
+  type t = Node.Trusted_validators_membership_change.t;
+
+  let read: (~file: string) => Lwt.t(list(t));
+  let write: (list(t), ~file: string) => Lwt.t(unit);
 };

--- a/bin/sidecli.re
+++ b/bin/sidecli.re
@@ -676,6 +676,12 @@ let setup_node =
         interop_context,
         ~file=interop_context_path,
       );
+    let.await () =
+      Files.Trusted_validators_membership_change.write(
+        [],
+        ~file=in_folder("trusted-validator-membership-change.json"),
+      );
+
     Lwt.return(`Ok());
   };
 

--- a/node/state.re
+++ b/node/state.re
@@ -13,6 +13,7 @@ module Uri_map = Map.Make(Uri);
 
 type t = {
   identity,
+  trusted_validator_membership_change: Trusted_validators_membership_change.Set.t,
   interop_context: Tezos_interop.Context.t,
   data_folder: string,
   pending_side_ops: list(Operation.Side_chain.t),
@@ -34,7 +35,13 @@ type t = {
 };
 
 let make =
-    (~identity, ~interop_context, ~data_folder, ~initial_validators_uri) => {
+    (
+      ~identity,
+      ~trusted_validator_membership_change,
+      ~interop_context,
+      ~data_folder,
+      ~initial_validators_uri,
+    ) => {
   let initial_block = Block.genesis;
   let initial_protocol = Protocol.make(~initial_block);
   let initial_signatures =
@@ -49,6 +56,7 @@ let make =
   };
   {
     identity,
+    trusted_validator_membership_change,
     interop_context,
     data_folder,
     pending_side_ops: [],

--- a/node/state.rei
+++ b/node/state.rei
@@ -12,6 +12,7 @@ module Address_map: Map.S with type key = Address.t;
 module Uri_map: Map.S with type key = Uri.t;
 type t = {
   identity,
+  trusted_validator_membership_change: Trusted_validators_membership_change.Set.t,
   interop_context: Tezos_interop.Context.t,
   data_folder: string,
   pending_side_ops: list(Operation.Side_chain.t),
@@ -29,6 +30,7 @@ type t = {
 let make:
   (
     ~identity: identity,
+    ~trusted_validator_membership_change: Trusted_validators_membership_change.Set.t,
     ~interop_context: Tezos_interop.Context.t,
     ~data_folder: string,
     ~initial_validators_uri: Address_map.t(Uri.t)

--- a/node/trusted_validators_membership_change.re
+++ b/node/trusted_validators_membership_change.re
@@ -1,0 +1,18 @@
+open Protocol;
+
+[@deriving (yojson, ord)]
+type action =
+  | Add
+  | Remove;
+
+[@deriving (yojson, ord)]
+type t = {
+  action,
+  address: Address.t,
+};
+
+module Set =
+  Set.Make({
+    type nonrec t = t;
+    let compare = compare;
+  });


### PR DESCRIPTION
## Problem

Add_validator operation needs to be verified against a list of trusted validators that a node operator maintains/obtains off-chain.

## Solution

This PR adds a new entry in the node state - `trusted_validators` - which a node sources from `trusted-validators.json`. This files is expected to contain keys and URIs of validators that a node operation doesn't mind being added to the chain as a validator in the future