### PR TITLE
Only accept trusted validators

### DIFF
--- a/bin/http_server.re
+++ b/bin/http_server.re
@@ -179,6 +179,15 @@ let handle_ticket_balance =
 let node = {
   let folder = Sys.argv[1];
   let.await identity = Files.Identity.read(~file=folder ++ "/identity.json");
+  let.await trusted_validators =
+    Files.Validators.read(~file=folder ++ "/trusted-validators.json")
+    |> Lwt.map(
+         List.fold_left(
+           (acc, (validator_key, _uri)) =>
+             Validators.(add({address: validator_key}, acc)),
+           Validators.empty,
+         ),
+       ); // Expected to contain validator keys that a node operation has verified off-chain
   let.await validators =
     Files.Validators.read(~file=folder ++ "/validators.json");
   let.await interop_context =
@@ -193,6 +202,7 @@ let node = {
   let node =
     State.make(
       ~identity,
+      ~trusted_validators,
       ~interop_context,
       ~data_folder=folder,
       ~initial_validators_uri,

--- a/node/state.re
+++ b/node/state.re
@@ -13,6 +13,7 @@ module Uri_map = Map.Make(Uri);
 
 type t = {
   identity,
+  trusted_validators: Validators.t,
   interop_context: Tezos_interop.Context.t,
   data_folder: string,
   pending_side_ops: list(Operation.Side_chain.t),
@@ -34,7 +35,13 @@ type t = {
 };
 
 let make =
-    (~identity, ~interop_context, ~data_folder, ~initial_validators_uri) => {
+    (
+      ~identity,
+      ~trusted_validators,
+      ~interop_context,
+      ~data_folder,
+      ~initial_validators_uri,
+    ) => {
   let initial_block = Block.genesis;
   let initial_protocol = Protocol.make(~initial_block);
   let initial_signatures =
@@ -49,6 +56,7 @@ let make =
   };
   {
     identity,
+    trusted_validators,
     interop_context,
     data_folder,
     pending_side_ops: [],

--- a/node/state.rei
+++ b/node/state.rei
@@ -12,6 +12,7 @@ module Address_map: Map.S with type key = Address.t;
 module Uri_map: Map.S with type key = Uri.t;
 type t = {
   identity,
+  trusted_validators: Validators.t,
   interop_context: Tezos_interop.Context.t,
   data_folder: string,
   pending_side_ops: list(Operation.Side_chain.t),
@@ -29,6 +30,7 @@ type t = {
 let make:
   (
     ~identity: identity,
+    ~trusted_validators: Validators.t,
     ~interop_context: Tezos_interop.Context.t,
     ~data_folder: string,
     ~initial_validators_uri: Address_map.t(Uri.t)

--- a/protocol/validators.re
+++ b/protocol/validators.re
@@ -39,6 +39,7 @@ let add = (validator, t) => {
   let new_proposer = t.current == None ? Some(validator) : t.current;
   {current: new_proposer, validators, length: List.length(validators)};
 };
+let mem = (validator, t) => List.mem(validator, t.validators);
 let remove = (validator, t) => {
   let validators = t.validators |> List.filter((!=)(validator));
   let length = List.length(validators);

--- a/protocol/validators.rei
+++ b/protocol/validators.rei
@@ -20,6 +20,7 @@ let update_current: (Address.t, t) => t;
 
 let empty: t;
 let add: (validator, t) => t;
+let mem: (validator, t) => bool;
 let remove: (validator, t) => t;
 
 let hash: t => BLAKE2B.t;


### PR DESCRIPTION
## Depends

- [ ] #182

## Problem

PR #182 adds support for adding and removing validators, but doesn't check if membership changes are trusted. 

## Solution

This PR builds on top of #182 and #184 to only accept trusted validators in Add_validators operation.